### PR TITLE
celery: change celery startup to limit memory usage

### DIFF
--- a/wazo_webhookd/controller.py
+++ b/wazo_webhookd/controller.py
@@ -2,26 +2,29 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
-import os
 import signal
 
 from functools import partial
-from multiprocessing import Process
 from threading import Thread
 from xivo import plugin_helpers
 from xivo.consul_helpers import ServiceCatalogRegistration
 from wazo_auth_client import Client as AuthClient
 
 from .bus import CoreBusConsumer
-from .celery import CoreCeleryWorker
-from .celery import app as celery_app
 from .rest_api import api, CoreRestApi
+from wazo_webhookd import celery
 
 logger = logging.getLogger(__name__)
 
 
 class Controller:
     def __init__(self, config):
+        # NOTE(sileht): Celery must be spawned before anything else, to ensure
+        # we don't fork the process after some database/rabbitmq connection
+        # have been established
+        celery.configure(config)
+        self._celery_process = celery.spawn_workers(config)
+
         self._service_discovery_args = [
             'wazo-webhookd',
             config.get('uuid'),
@@ -30,12 +33,9 @@ class Controller:
             config['bus'],
             lambda: True,
         ]
+
         self._auth_client = AuthClient(**config['auth'])
         self._bus_consumer = CoreBusConsumer(config)
-        self._celery_worker = CoreCeleryWorker(config)
-        self._celery_process = Process(
-            target=self._celery_worker.run, name='celery_process'
-        )
         self.rest_api = CoreRestApi(config)
         self._service_manager = plugin_helpers.load(
             namespace='wazo_webhookd.services',
@@ -43,7 +43,6 @@ class Controller:
             dependencies={
                 'api': api,
                 'bus_consumer': self._bus_consumer,
-                'celery': celery_app,
                 'config': config,
                 'auth_client': self._auth_client,
             },
@@ -62,7 +61,6 @@ class Controller:
     def run(self):
         logger.info('wazo-webhookd starting...')
         signal.signal(signal.SIGTERM, partial(_sigterm_handler, self))
-        self._celery_process.start()
         bus_consumer_thread = Thread(
             target=self._bus_consumer.run, name='bus_consumer_thread'
         )
@@ -73,7 +71,7 @@ class Controller:
         finally:
             logger.info('wazo-webhookd stopping...')
             self._bus_consumer.should_stop = True
-            os.kill(self._celery_process.pid, signal.SIGTERM)
+            self._celery_process.terminate()
 
             logger.debug('waiting for remaining threads/subprocesses...')
             bus_consumer_thread.join()

--- a/wazo_webhookd/plugins/subscription/bus.py
+++ b/wazo_webhookd/plugins/subscription/bus.py
@@ -1,129 +1,15 @@
 # Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import datetime
 import functools
 import logging
 import kombu.exceptions
-from pkg_resources import EntryPoint
 import uuid
 
-import celery
-
-from wazo_webhookd.celery import app
-from wazo_webhookd.services.helpers import HookRetry, HookExpectedError
-
+from .celery_tasks import hook_runner_task
 from .schema import subscription_schema
-from .service import SubscriptionService
 
 logger = logging.getLogger(__name__)
-
-
-@app.task(bind=True)
-def hook_runner_task(task, hook_uuid, ep_name, config, subscription, event):
-    service = SubscriptionService(config)
-    try:
-        hook_runner(service, task, hook_uuid, ep_name, config, subscription, event)
-    finally:
-        service.close()
-
-
-def hook_runner(service, task, hook_uuid, ep_name, config, subscription, event):
-
-    hook = EntryPoint.parse(ep_name).resolve()
-    logger.info("running hook %s (%s) for event: %s", ep_name, hook_uuid, event)
-
-    try:
-        event_name = event['data']['name']
-    except KeyError:
-        event_name = '<unknown>'
-
-    started = datetime.datetime.utcnow()
-    try:
-        detail = hook.run(task, config, subscription, event)
-    except HookRetry as e:
-        if task.request.retries + 1 == config["hook_max_attempts"]:
-            verb = "reached max retries"
-            status = "error"
-        else:
-            verb = "will retry"
-            status = "failure"
-        logger.error(
-            "Hook `%s/%s` (%s) %s (%s/%s): %s",
-            ep_name,
-            hook_uuid,
-            event_name,
-            verb,
-            task.request.retries + 1,
-            config["hook_max_attempts"],
-            e.detail,
-        )
-        ended = datetime.datetime.utcnow()
-        service.create_hook_log(
-            hook_uuid,
-            subscription["uuid"],
-            status,
-            task.request.retries + 1,
-            config["hook_max_attempts"],
-            started,
-            ended,
-            event,
-            e.detail,
-        )
-
-        retry_backoff = int(2 ** task.request.retries)
-        try:
-            task.retry(
-                countdown=retry_backoff, max_retries=config["hook_max_attempts"] - 1
-            )
-        except celery.exceptions.MaxRetriesExceededError:
-            return
-    except Exception as e:
-        if isinstance(e, HookExpectedError):
-            detail = e.detail
-            logger.error(
-                "Hook `%s/%s` (%s) failure: %s", ep_name, hook_uuid, event_name, detail
-            )
-        else:
-            # TODO(sileht): Maybe we should not record the raw error
-            detail = {'error': str(e)}
-            logger.error(
-                "Hook `%s/%s` (%s) error: %s",
-                ep_name,
-                hook_uuid,
-                event_name,
-                detail,
-                exc_info=True,
-            )
-        ended = datetime.datetime.utcnow()
-        service.create_hook_log(
-            hook_uuid,
-            subscription["uuid"],
-            "error",
-            task.request.retries + 1,
-            config["hook_max_attempts"],
-            started,
-            ended,
-            event,
-            detail,
-        )
-
-    else:
-        logger.debug(
-            "Hook `%s/%s` (%s) succeed: %s", ep_name, hook_uuid, event_name, detail
-        )
-        ended = datetime.datetime.utcnow()
-        service.create_hook_log(
-            hook_uuid,
-            subscription["uuid"],
-            "success",
-            task.request.retries + 1,
-            config["hook_max_attempts"],
-            started,
-            ended,
-            event,
-            detail or {},
-        )
 
 
 class SubscriptionBusEventHandler:

--- a/wazo_webhookd/plugins/subscription/celery_tasks.py
+++ b/wazo_webhookd/plugins/subscription/celery_tasks.py
@@ -1,0 +1,121 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+import datetime
+import logging
+from pkg_resources import EntryPoint
+
+import celery
+
+from wazo_webhookd.celery import app
+from wazo_webhookd.services.helpers import HookRetry, HookExpectedError
+
+from .service import SubscriptionService
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(bind=True)
+def hook_runner_task(task, hook_uuid, ep_name, config, subscription, event):
+    service = SubscriptionService(config)
+    try:
+        hook_runner(service, task, hook_uuid, ep_name, config, subscription, event)
+    finally:
+        service.close()
+
+
+def hook_runner(service, task, hook_uuid, ep_name, config, subscription, event):
+
+    hook = EntryPoint.parse(ep_name).resolve()
+    logger.info("running hook %s (%s) for event: %s", ep_name, hook_uuid, event)
+
+    try:
+        event_name = event['data']['name']
+    except KeyError:
+        event_name = '<unknown>'
+
+    started = datetime.datetime.utcnow()
+    try:
+        detail = hook.run(task, config, subscription, event)
+    except HookRetry as e:
+        if task.request.retries + 1 == config["hook_max_attempts"]:
+            verb = "reached max retries"
+            status = "error"
+        else:
+            verb = "will retry"
+            status = "failure"
+        logger.error(
+            "Hook `%s/%s` (%s) %s (%s/%s): %s",
+            ep_name,
+            hook_uuid,
+            event_name,
+            verb,
+            task.request.retries + 1,
+            config["hook_max_attempts"],
+            e.detail,
+        )
+        ended = datetime.datetime.utcnow()
+        service.create_hook_log(
+            hook_uuid,
+            subscription["uuid"],
+            status,
+            task.request.retries + 1,
+            config["hook_max_attempts"],
+            started,
+            ended,
+            event,
+            e.detail,
+        )
+
+        retry_backoff = int(2 ** task.request.retries)
+        try:
+            task.retry(
+                countdown=retry_backoff, max_retries=config["hook_max_attempts"] - 1
+            )
+        except celery.exceptions.MaxRetriesExceededError:
+            return
+    except Exception as e:
+        if isinstance(e, HookExpectedError):
+            detail = e.detail
+            logger.error(
+                "Hook `%s/%s` (%s) failure: %s", ep_name, hook_uuid, event_name, detail
+            )
+        else:
+            # TODO(sileht): Maybe we should not record the raw error
+            detail = {'error': str(e)}
+            logger.error(
+                "Hook `%s/%s` (%s) error: %s",
+                ep_name,
+                hook_uuid,
+                event_name,
+                detail,
+                exc_info=True,
+            )
+        ended = datetime.datetime.utcnow()
+        service.create_hook_log(
+            hook_uuid,
+            subscription["uuid"],
+            "error",
+            task.request.retries + 1,
+            config["hook_max_attempts"],
+            started,
+            ended,
+            event,
+            detail,
+        )
+
+    else:
+        logger.debug(
+            "Hook `%s/%s` (%s) succeed: %s", ep_name, hook_uuid, event_name, detail
+        )
+        ended = datetime.datetime.utcnow()
+        service.create_hook_log(
+            hook_uuid,
+            subscription["uuid"],
+            "success",
+            task.request.retries + 1,
+            config["hook_max_attempts"],
+            started,
+            ended,
+            event,
+            detail or {},
+        )


### PR DESCRIPTION
Currently celery in forked from webhookd and this after webhookd have
been fully setuped, this allocate ton of useless resources in celery
workers.

This change loads celery earlier and only load the tasks module and
nothing else.

Configuration options have also changed to the new celery 4.0 format.
Some have been removed as they are now the defaults.