### PR TITLE
dependencies: add the version on the kombu dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Depends:
  python3-flask-cors,
  python3-flask-restful,
  python3-httpx,
- python3-kombu,
+ python3-kombu (>= 4.2.1-3),
  python3-marshmallow,
  python3-psycopg2,
  python3-pyfcm,


### PR DESCRIPTION
there are errors in the logs of the service if it starts with the stretch
version of python3-kombu.