### PR TITLE
apns2: support ios 13

### DIFF
--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -224,9 +224,20 @@ class PushNotification(object):
                 cert.write(self.external_config['ios_apn_certificate'] + "\r\n")
                 cert.write(self.external_config['ios_apn_private'])
 
-            headers = {'apns-push-type': 'alert', 'apns-topic': 'io.wazo.songbird.voip'}
+            headers = {
+                'apns-topic': 'io.wazo.songbird.voip',
+                'apns-priority': 5,
+                'apns-expiration': 0,
+            }
 
-            payload = {'aps': {'alert': data, 'badge': 1, 'sound': "default"}}
+            payload = {
+                'aps': {
+                    'alert': data,
+                    'badge': 1,
+                    'sound': "default",
+                    'content-available': 1,
+                }
+            }
 
             if self.external_config['is_sandbox']:
                 server = 'api.sandbox.push.apple.com'

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -226,8 +226,8 @@ class PushNotification(object):
 
             headers = {
                 'apns-topic': 'io.wazo.songbird.voip',
-                'apns-priority': 5,
-                'apns-expiration': 0,
+                'apns-priority': "5",
+                'apns-expiration': "0",
             }
 
             payload = {


### PR DESCRIPTION
apns-expiration must be set to 0, to ensure push have been delivered
at least once.

apns-priority must be 5 to wakeup (side effect app wakeup may not be
instant)

aps must only containts `content-available = 1` to wake up application

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns?language=objc
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification?language=objc
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app?language=objc

```
apns-expiration

The date at which the notification is no longer valid. This value is a
UNIX epoch expressed in seconds (UTC). If the value is nonzero, APNs
stores the notification and tries to deliver it at least once, repeating
the attempt as needed until the specified date. If the value is 0, APNs
attempts to deliver the notification only once and does not store it.
```

```
apns-priority

The priority of the notification. If you omit this header, APNs sets the
notification priority to 10.

Specify 10 to send the notification immediately. A value of 10 is
appropriate for notifications that trigger an alert, play a sound, or
badge the app’s icon. It's an error to specify this priority for a
notification whose payload contains the content-available key.

Specify 5 to send the notification based on power considerations on the
user’s device. Use this priority for notifications whose payload
includes the content-available key. Notifications with this priority
might be grouped and delivered in bursts to the user’s device. They may
also be throttled, and in some cases not delivered.
```

```
content-available

The background notification flag. To perform a silent background update,
specify the value 1 and don't include the alert, badge, or sound keys in
your payload. See Pushing Background Updates to Your App.
```