### PR TITLE
Remove logs relationship of Subscription orm object

### DIFF
--- a/wazo_webhookd/database/models.py
+++ b/wazo_webhookd/database/models.py
@@ -138,10 +138,6 @@ class Subscription(object):
         for attribute, value in attributes.items():
             setattr(self, attribute, value)
 
-    @property
-    def logs(self):
-        return self.logs_rel
-
 
 metadata = Base.metadata
 subscription_table = Table(
@@ -170,9 +166,6 @@ mapper(
         ),
         'metadata_rel': relationship(
             SubscriptionMetadatum, lazy='joined', cascade='all, delete-orphan'
-        ),
-        'logs_rel': relationship(
-            SubscriptionLog, lazy='joined', cascade='all, delete-orphan'
         ),
     },
 )


### PR DESCRIPTION
This attribute is no more used.

If subscription orm object is loaded, due to the lazy=joined, the whole logs table
is loaded too and maybe refreshed along as we run hooks in certain case.

It's still unclear why the memory wasn't freed when this orm object is
loaded. It's maybe due to the manual construction of the sqlachemy
Mapper object.

A future change will remove the custom sqla mapper to the usual
declarative_base().