### PR TITLE
integration tests: use until.timeout instead of until.tries

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -177,7 +177,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
             except requests.exceptions.ConnectionError:
                 raise AssertionError()
 
-        until.assert_(subscribed, tries=10, interval=0.5)
+        until.assert_(subscribed, timeout=10, interval=0.5)
 
     def ensure_webhookd_not_consume_uuid(self, uuid):
         sentinel = self.make_sentinel()
@@ -188,7 +188,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
             except requests.exceptions.ConnectionError:
                 raise AssertionError()
 
-        until.assert_(subscribed, tries=10, interval=0.5)
+        until.assert_(subscribed, timeout=10, interval=0.5)
 
     @contextmanager
     def auth_stopped(self):
@@ -196,7 +196,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
         yield
         self.start_service('auth')
         auth = self.make_auth()
-        until.true(auth.is_up, tries=5, message='wazo-auth did not come back up')
+        until.true(auth.is_up, timeout=5, message='wazo-auth did not come back up')
         self.configured_wazo_auth()
 
     @contextmanager
@@ -205,4 +205,4 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
         yield
         self.start_service('rabbitmq')
         bus = self.make_bus()
-        until.true(bus.is_up, tries=5, message='rabbitmq did not come back up')
+        until.true(bus.is_up, timeout=5, message='rabbitmq did not come back up')

--- a/integration_tests/suite/test_celery.py
+++ b/integration_tests/suite/test_celery.py
@@ -31,4 +31,4 @@ class TestCeleryWorks(BaseIntegrationTest):
             assert_that(master_found, equal_to(True))
             assert_that(worker_count, equal_to(3), output)
 
-        until.assert_(check_ps, tries=10, interval=0.5)
+        until.assert_(check_ps, timeout=10, interval=0.5)

--- a/integration_tests/suite/test_http_callback.py
+++ b/integration_tests/suite/test_http_callback.py
@@ -189,7 +189,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -219,7 +219,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -252,7 +252,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -290,7 +290,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=2, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -347,7 +347,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -372,14 +372,14 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/new-url'}
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
         until.assert_(
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -402,7 +402,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -425,7 +425,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -439,7 +439,7 @@ class TestHTTPCallback(BaseIntegrationTest):
 
         # FIXME(sileht): BusClient should reconnect automatically
         self.bus = self.make_bus()
-        until.true(self.bus.is_up, tries=5, message='rabbitmq did not come back up')
+        until.true(self.bus.is_up, timeout=5, message='rabbitmq did not come back up')
 
         self.bus.publish(
             trigger_event(),
@@ -451,7 +451,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -482,7 +482,7 @@ class TestHTTPCallback(BaseIntegrationTest):
                     ],
                 }
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -511,7 +511,7 @@ class TestHTTPCallback(BaseIntegrationTest):
                     ],
                 }
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -534,7 +534,7 @@ class TestHTTPCallback(BaseIntegrationTest):
                     'body': '{"body_keỳ": "body_vàlue"}',
                 }
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -553,7 +553,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test', 'body': 'trigger value'}
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -586,7 +586,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -612,7 +612,7 @@ class TestHTTPCallback(BaseIntegrationTest):
                     ],
                 }
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -653,7 +653,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -685,7 +685,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
         assert_that(self.sentinel.called(), is_(False))
@@ -706,7 +706,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         def sentinel_was_called():
             assert_that(self.sentinel.called(), is_(True))
 
-        until.assert_(sentinel_was_called, tries=10, interval=0.5)
+        until.assert_(sentinel_was_called, timeout=10, interval=0.5)
 
     @subscription(TEST_SUBSCRIPTION_FILTER_WAZO_UUID)
     def test_given_http_subscription_with_wazo_uuid_when_bus_events_then_only_callback_when_wazo_uuid_match(
@@ -734,7 +734,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=1, exact=True
             ),
-            tries=10,
+            timeout=10,
             interval=0.5,
         )
 
@@ -760,7 +760,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=3, exact=True
             ),
-            tries=20,
+            timeout=20,
             interval=0.5,
         )
 
@@ -782,7 +782,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=2, exact=True
             ),
-            tries=20,
+            timeout=20,
             interval=0.5,
         )
 
@@ -892,7 +892,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=3, exact=True
             ),
-            tries=30,
+            timeout=30,
             interval=0.5,
         )
 
@@ -903,7 +903,7 @@ class TestHTTPCallback(BaseIntegrationTest):
             self.make_third_party_verify_callback(
                 request={'method': 'GET', 'path': '/test'}, count=3, exact=True
             ),
-            tries=30,
+            timeout=30,
             interval=0.5,
         )
         webhookd = self.make_webhookd(MASTER_TOKEN)

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -68,7 +68,7 @@ class TestMobileCallback(BaseIntegrationTest):
             logs = func()
             assert_that(logs['total'], number)
 
-        until.assert_(check, tries=10, interval=0.5)
+        until.assert_(check, timeout=10, interval=0.5)
 
     def test_workflow_fcm(self):
         third_party = MockServerClient(

--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -23,14 +23,14 @@ class TestStatusRabbitMQStops(BaseIntegrationTest):
             result = webhookd.status.get()
             assert_that(result['bus_consumer'], has_entries({'status': 'ok'}))
 
-        until.assert_(all_connections_ok, tries=20)
+        until.assert_(all_connections_ok, timeout=20)
 
         def rabbitmq_is_down():
             result = webhookd.status.get()
             assert_that(result['bus_consumer']['status'], equal_to('fail'))
 
         with self.rabbitmq_stopped():
-            until.assert_(rabbitmq_is_down, tries=5)
+            until.assert_(rabbitmq_is_down, timeout=5)
 
 
 class TestStatusAllOK(BaseIntegrationTest):
@@ -45,4 +45,4 @@ class TestStatusAllOK(BaseIntegrationTest):
             result = webhookd.status.get()
             assert_that(result['bus_consumer'], has_entries({'status': 'ok'}))
 
-        until.assert_(all_connections_ok, tries=20)
+        until.assert_(all_connections_ok, timeout=20)


### PR DESCRIPTION
reason: more explicit, and some tests have a timeout too short. With
interval=0.5, timeout effectively doubles the timeout time