### PR TITLE
zuul: remove debian-packaging-template check

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -2,7 +2,6 @@
     templates:
       - wazo-tox-py37
       - wazo-tox-linters
-      - debian-packaging-template
     check:
       jobs:
         - webhookd-tox-integration:

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -16,3 +16,5 @@
     description: Run webhookd integration tests
     parent: wazo-tox-integration
     timeout: 3600
+    vars:
+      integration_test_timeout: 60


### PR DESCRIPTION
    reason: this solution should be temporary. Since our postinst script
    execute `wazo-webhookd-init-amqp` that need rabbitmq, this package
    should depends on rabbitmq-server. But it do not follow our vision of
    distributed service. So waiting a refactor of the debian packaging to
    follow distributed service, we just remove the check