### PR TITLE
test_status: increase timeout for closing rabbitmq

### DIFF
--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -30,7 +30,7 @@ class TestStatusRabbitMQStops(BaseIntegrationTest):
             assert_that(result['bus_consumer']['status'], equal_to('fail'))
 
         with self.rabbitmq_stopped():
-            until.assert_(rabbitmq_is_down, timeout=5)
+            until.assert_(rabbitmq_is_down, timeout=10)
 
 
 class TestStatusAllOK(BaseIntegrationTest):


### PR DESCRIPTION
reason: on slow host, the rabbitmq container can be slow to shutdown
related to https://jenkins.wazo.community/job/integration-tests-nolock/13483/console