### PR TITLE
debian: use PYTHONUNBEFFERED instead of python -u

### DIFF
--- a/debian/wazo-webhookd.service
+++ b/debian/wazo-webhookd.service
@@ -4,8 +4,9 @@ After=network.target
 Before=monit.service
 
 [Service]
+Environment=PYTHONUNBUFFERED=TRUE
 ExecStartPre=/usr/bin/install -d -o wazo-webhookd -g wazo-webhookd /run/wazo-webhookd
-ExecStart=/usr/bin/python3 /usr/bin/wazo-webhookd
+ExecStart=/usr/bin/wazo-webhookd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
reason: to see the daemon name in the journalctl/syslog instead of
`python3`