### PR TITLE
test-requirements: use psycopg2-binary

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -2,7 +2,7 @@ docker-compose
 kombu
 nose
 openapi-spec-validator
-psycopg2
+psycopg2-binary
 pyhamcrest
 requests
 sqlalchemy


### PR DESCRIPTION
reason: avoid to compile psycopg2
  * improve installation speed
  * avoid compilation errors because some headers are missing