### PR TITLE
mobile: send sip-call-id with push notification

### DIFF
--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -107,7 +107,10 @@ class TestMobileCallback(BaseIntegrationTest):
                         'type': 'JSON',
                         'json': {
                             'data': {
-                                'items': {'call_id': 'some-call-id'},
+                                'items': {
+                                    'call_id': 'some-call-id',
+                                    'sip_call_id': 'some-sip-call-id',
+                                },
                                 'notification_type': 'callAnswered',
                             }
                         },
@@ -128,7 +131,10 @@ class TestMobileCallback(BaseIntegrationTest):
                         'type': 'JSON',
                         'json': {
                             'data': {
-                                'items': {'call_id': 'some-call-id'},
+                                'items': {
+                                    'call_id': 'some-call-id',
+                                    'sip_call_id': 'some-sip-call-id',
+                                },
                                 'notification_type': 'callEnded',
                             }
                         },
@@ -222,6 +228,7 @@ class TestMobileCallback(BaseIntegrationTest):
                     'status': 'Up',
                     'is_caller': False,
                     'peer_caller_id_number': 'caller-id',
+                    'sip_call_id': 'some-sip-call-id',
                 },
             },
             routing_key=SOME_ROUTING_KEY,
@@ -258,6 +265,7 @@ class TestMobileCallback(BaseIntegrationTest):
                 'data': {
                     'call_id': 'some-call-id',
                     'peer_caller_id_number': 'caller-id',
+                    'sip_call_id': 'some-sip-call-id',
                 },
             },
             routing_key=SOME_ROUTING_KEY,
@@ -315,7 +323,10 @@ class TestMobileCallback(BaseIntegrationTest):
                         'type': 'JSON',
                         'json': {
                             'data': {
-                                'items': {'call_id': 'some-call-id'},
+                                'items': {
+                                    'call_id': 'some-call-id',
+                                    'sip_call_id': 'some-sip-call-id',
+                                },
                                 'notification_type': 'callAnswered',
                             }
                         },
@@ -336,7 +347,10 @@ class TestMobileCallback(BaseIntegrationTest):
                         'type': 'JSON',
                         'json': {
                             'data': {
-                                'items': {'call_id': 'some-call-id'},
+                                'items': {
+                                    'call_id': 'some-call-id',
+                                    'sip_call_id': 'some-sip-call-id',
+                                },
                                 'notification_type': 'callEnded',
                             }
                         },
@@ -426,6 +440,7 @@ class TestMobileCallback(BaseIntegrationTest):
                     'status': 'Up',
                     'is_caller': False,
                     'peer_caller_id_number': 'caller-id',
+                    'sip_call_id': 'some-sip-call-id',
                 },
             },
             routing_key=SOME_ROUTING_KEY,
@@ -462,6 +477,7 @@ class TestMobileCallback(BaseIntegrationTest):
                 'data': {
                     'call_id': 'some-call-id',
                     'peer_caller_id_number': 'caller-id',
+                    'sip_call_id': 'some-sip-call-id',
                 },
             },
             routing_key=SOME_ROUTING_KEY,

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -180,7 +180,7 @@ class PushNotification(object):
                 'Call Answered',
                 'From: {}'.format(data['peer_caller_id_number']),
                 'wazo-notification-call-answered',
-                dict(call_id=data['call_id']),
+                dict(call_id=data['call_id'], sip_call_id=data['sip_call_id']),
             )
 
     def callEnded(self, data):
@@ -190,7 +190,7 @@ class PushNotification(object):
                 'Call Ended',
                 'From: {}'.format(data['peer_caller_id_number']),
                 'wazo-notification-call-ended',
-                dict(call_id=data['call_id']),
+                dict(call_id=data['call_id'], sip_call_id=data['sip_call_id']),
             )
 
     def voicemailReceived(self, data):


### PR DESCRIPTION
Why:

* A mobile application with WebRTC only knows the SIP call-id, not the
Wazo call_id.