### PR TITLE
webhook logs: fix crash when subscription is deleted

### DIFF
--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -201,3 +201,21 @@ class TestDatabase(AssetLaunchingTestCase):
 
         logs = service.get_logs(subscription_uuid)
         assert_that(len(logs), equal_to(4))
+
+    def test_subscription_log_on_subscription_deleted(self):
+        service = SubscriptionService({'db_uri': self.db_uri})
+        subscription_uuid_not_found = str(uuid.uuid4())
+
+        service.create_hook_log(
+            uuid=str(uuid.uuid4()),
+            subscription_uuid=subscription_uuid_not_found,
+            status="failure",
+            attempts=1,
+            max_attempts=3,
+            started_at=datetime.datetime.now(),
+            ended_at=datetime.datetime.now() + datetime.timedelta(minutes=1),
+            event={},
+            detail={},
+        )
+
+        # assert no exception

--- a/wazo_webhookd/plugins/subscription/service.py
+++ b/wazo_webhookd/plugins/subscription/service.py
@@ -218,5 +218,6 @@ class SubscriptionService(object):
                         "subscription %s have been deleted in the meantime",
                         subscription_uuid,
                     )
+                    session.rollback()
                 else:
                     raise


### PR DESCRIPTION
Why:

* The database session needs to be rolled back when an exception occurs.
* All subsequent webhook logs were stuck by this broken DB session.