### PR TITLE
tests: fix hamcrest assertions

### DIFF
--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -7,7 +7,16 @@ import uuid
 
 from contextlib import contextmanager
 from functools import partial
-from hamcrest import assert_that, calling, has_entries, is_, none, not_none, raises
+from hamcrest import (
+    assert_that,
+    calling,
+    equal_to,
+    has_entries,
+    is_,
+    none,
+    not_none,
+    raises,
+)
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker, scoped_session
@@ -184,11 +193,11 @@ class TestDatabase(AssetLaunchingTestCase):
             add_log(days_ago=days)
 
         logs = service.get_logs(subscription_uuid)
-        assert_that(len(logs), 10)
+        assert_that(len(logs), equal_to(10))
 
         with service.rw_session() as session:
             days_to_purge = 2
             SubscriptionLogsPurger().purge(days_to_purge, session)
 
         logs = service.get_logs(subscription_uuid)
-        assert_that(len(logs), 4)
+        assert_that(len(logs), equal_to(4))

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -6,7 +6,7 @@ import json
 
 import requests
 
-from hamcrest import assert_that, has_entries, has_entry
+from hamcrest import assert_that, equal_to, has_entries, has_entry
 from mockserver import MockServerClient
 from xivo_test_helpers import until
 

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -70,7 +70,7 @@ class TestMobileCallback(BaseIntegrationTest):
     def _wait_items(func, number=1):
         def check():
             logs = func()
-            assert_that(logs['total'], number)
+            assert_that(logs['total'], equal_to(number))
 
         until.assert_(check, timeout=10, interval=0.5)
 
@@ -120,7 +120,7 @@ class TestMobileCallback(BaseIntegrationTest):
         webhookd = self.make_webhookd(MASTER_TOKEN)
         self._wait_items(functools.partial(webhookd.subscriptions.list, recurse=True))
         subscriptions = webhookd.subscriptions.list(recurse=True)
-        assert_that(subscriptions['total'], 1)
+        assert_that(subscriptions['total'], equal_to(1))
         assert_that(
             subscriptions['items'][0],
             has_entries(
@@ -160,7 +160,7 @@ class TestMobileCallback(BaseIntegrationTest):
         )
 
         logs = webhookd.subscriptions.get_logs(subscription["uuid"])
-        assert_that(logs['total'], 1)
+        assert_that(logs['total'], equal_to(1))
         assert_that(
             logs['items'][0],
             has_entries(
@@ -207,7 +207,7 @@ class TestMobileCallback(BaseIntegrationTest):
         webhookd = self.make_webhookd(MASTER_TOKEN)
         self._wait_items(functools.partial(webhookd.subscriptions.list, recurse=True))
         subscriptions = webhookd.subscriptions.list(recurse=True)
-        assert_that(subscriptions['total'], 1)
+        assert_that(subscriptions['total'], equal_to(1))
         assert_that(
             subscriptions['items'][0],
             has_entries(
@@ -247,7 +247,7 @@ class TestMobileCallback(BaseIntegrationTest):
         )
 
         logs = webhookd.subscriptions.get_logs(subscription["uuid"])
-        assert_that(logs['total'], 1)
+        assert_that(logs['total'], equal_to(1))
         assert_that(
             logs['items'][0],
             has_entries(


### PR DESCRIPTION
Why:

* When the second argument to assert_that is not a matcher, the
signature becomes: assert_that(assertion, [reason]), so using a simple
integer as matcher does not implicitly use equal_to.