### PR TITLE
fix sqlalchemy buster migration

### DIFF
--- a/alembic/versions/df313e703ee8_remove_unecessary_sequence.py
+++ b/alembic/versions/df313e703ee8_remove_unecessary_sequence.py
@@ -1,0 +1,27 @@
+"""remove_unecessary_sequence
+
+Revision ID: df313e703ee8
+Revises: cab8bbbdcfae
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'df313e703ee8'
+down_revision = 'cab8bbbdcfae'
+
+seq = sa.Sequence('webhookd_subscription_log_attempts_seq')
+
+
+def upgrade():
+    op.alter_column('webhookd_subscription_log', 'attempts', server_default=None)
+    op.execute('DROP SEQUENCE IF EXISTS webhookd_subscription_log_attempts_seq;')
+
+
+def downgrade():
+    op.execute('CREATE SEQUENCE webhookd_subscription_log_attempts_seq;')
+    op.alter_column(
+        'webhookd_subscription_log', 'attempts', server_default=seq.next_value()
+    )


### PR DESCRIPTION
Before sqlalchemy 1.1, integer primary key created automatically a sequence,
but for >= 1.1 if primary was composed, then the sequence is not
created.
We need to have the same schema for upgrade and install
See WAZO-1603 for more information