### PR TITLE
test: remove silence loggers

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,7 +1,6 @@
 # Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import logging
 import os
 
 import requests
@@ -18,9 +17,6 @@ from xivo_test_helpers.auth import AuthClient
 from xivo_test_helpers.bus import BusClient
 
 from .wait_strategy import WaitStrategy
-
-logging.getLogger('amqp').setLevel(logging.INFO)
-logging.getLogger('stevedore.extension').setLevel(level=logging.INFO)
 
 VALID_TOKEN = "valid-token"
 


### PR DESCRIPTION
reason: loggers already silenced by xivo-test-helpers