### PR TITLE
Pull request for WAZO-2225-runtime-debug-logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get -q update
 RUN apt-get -yq install gcc
 
-COPY . /usr/src/wazo-webhookd
+COPY requirements.txt /usr/src/wazo-webhookd/
 WORKDIR /usr/src/wazo-webhookd
 RUN pip install -r requirements.txt
+
+COPY setup.py /usr/src/wazo-webhookd/
+COPY wazo_webhookd /usr/src/wazo-webhookd/wazo_webhookd
 RUN python setup.py install
 
 FROM python:3.7-slim-buster AS build-image

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -10,7 +10,7 @@ egg-info:
 webhookd:
 	docker build -t wazoplatform/wazo-webhookd ..
 
-webhookd-test: egg-info
+webhookd-test: webhookd egg-info
 	docker build --no-cache -t wazo-webhookd-test -f Dockerfile ..
 
 db:

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -1,7 +1,12 @@
 # Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, has_key, has_entry
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_key,
+    has_entry,
+)
 
 from .helpers.base import BaseIntegrationTest
 from .helpers.base import MASTER_TOKEN
@@ -38,10 +43,12 @@ class TestConfig(BaseIntegrationTest):
             }
         ]
 
-        webhookd.config.patch(debug_true_config)
+        debug_true_patched_config = webhookd.config.patch(debug_true_config)
         debug_true_config = webhookd.config.get()
         assert_that(debug_true_config, has_entry('debug', True))
+        assert_that(debug_true_patched_config, equal_to(debug_true_config))
 
-        webhookd.config.patch(debug_false_config)
+        debug_false_patched_config = webhookd.config.patch(debug_false_config)
         debug_false_config = webhookd.config.get()
         assert_that(debug_false_config, has_entry('debug', False))
+        assert_that(debug_false_patched_config, equal_to(debug_false_config))

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -1,8 +1,7 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that
-from hamcrest import has_key
+from hamcrest import assert_that, has_key, has_entry
 
 from .helpers.base import BaseIntegrationTest
 from .helpers.base import MASTER_TOKEN
@@ -20,3 +19,29 @@ class TestConfig(BaseIntegrationTest):
         result = webhookd.config.get()
 
         assert_that(result, has_key('rest_api'))
+
+    def test_update_config(self):
+        webhookd = self.make_webhookd(MASTER_TOKEN)
+
+        debug_true_config = [
+            {
+                'op': 'replace',
+                'path': '/debug',
+                'value': True,
+            }
+        ]
+        debug_false_config = [
+            {
+                'op': 'replace',
+                'path': '/debug',
+                'value': False,
+            }
+        ]
+
+        webhookd.config.patch(debug_true_config)
+        debug_true_config = webhookd.config.get()
+        assert_that(debug_true_config, has_entry('debug', True))
+
+        webhookd.config.patch(debug_false_config)
+        debug_false_config = webhookd.config.get()
+        assert_that(debug_false_config, has_entry('debug', False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ flask-cors==3.0.7
 flask-restful==0.3.7
 flask==1.0.2
 jinja2==2.10
+jsonpatch==1.21
 kombu==4.6.11
 setproctitle==1.1.10
 marshmallow==3.0.0b14

--- a/wazo_webhookd/plugins/config/api.yml
+++ b/wazo_webhookd/plugins/config/api.yml
@@ -14,8 +14,11 @@ paths:
     patch:
       produces:
         - application/json
-      summary: Update the current configuration. Changes are not persistent across service restart.
-      description: '**Required ACL:** `webhookd.config.update`'
+      summary: Update the current configuration.
+      description: |
+        **Required ACL:** `webhookd.config.update`
+
+        Changes are not persistent across service restart.
       operationId: patchConfig
       tags:
         - config

--- a/wazo_webhookd/plugins/config/api.yml
+++ b/wazo_webhookd/plugins/config/api.yml
@@ -11,8 +11,6 @@ paths:
       responses:
         '200':
           'description': The configuration of the service
-
-  /config:
     patch:
       produces:
         - application/json
@@ -22,7 +20,7 @@ paths:
       tags:
         - config
       parameters:
-        - $ref: "#/parameters/JSONPatch"
+        - $ref: "#/parameters/ConfigPatch"
       responses:
         '204':
           description: The config was updated
@@ -30,17 +28,24 @@ paths:
           description: The given confiuration is invalid
 parameters:
   ConfigPatch:
+    name: ConfigPatch
+    in: body
+    required: true
     description: See https://en.wikipedia.org/wiki/JSON_Patch.
-    type: array
-    items:
-      type: object
-      properties:
-        op:
-          type: string
-          description: "Patch operation. Supported operations: `replace`."
-        path:
-          type: string
-          description: "JSON path to operate on. Supported paths: `/debug`."
-        value:
-          type: object
-          description: "The new value for the operation. Type of value is dependent of `path`"
+    schema:
+      type: array
+      items:
+        $ref: '#/definitions/ConfigPatchItem'
+
+definitions:
+  ConfigPatchItem:
+    properties:
+      op:
+        type: string
+        description: "Patch operation. Supported operations: `replace`."
+      path:
+        type: string
+        description: "JSON path to operate on. Supported paths: `/debug`."
+      value:
+        type: object
+        description: "The new value for the operation. Type of value is dependent of `path`"

--- a/wazo_webhookd/plugins/config/api.yml
+++ b/wazo_webhookd/plugins/config/api.yml
@@ -25,8 +25,8 @@ paths:
       parameters:
         - $ref: "#/parameters/ConfigPatch"
       responses:
-        '204':
-          description: The config was updated
+        '200':
+          description: The updated configuration of the service
         '400':
           description: The given confiuration is invalid
 parameters:

--- a/wazo_webhookd/plugins/config/api.yml
+++ b/wazo_webhookd/plugins/config/api.yml
@@ -11,3 +11,36 @@ paths:
       responses:
         '200':
           'description': The configuration of the service
+
+  /config:
+    patch:
+      produces:
+        - application/json
+      summary: Update the current configuration. Changes are not persistent across service restart.
+      description: '**Required ACL:** `webhookd.config.update`'
+      operationId: patchConfig
+      tags:
+        - config
+      parameters:
+        - $ref: "#/parameters/JSONPatch"
+      responses:
+        '204':
+          description: The config was updated
+        '400':
+          description: The given confiuration is invalid
+parameters:
+  ConfigPatch:
+    description: See https://en.wikipedia.org/wiki/JSON_Patch.
+    type: array
+    items:
+      type: object
+      properties:
+        op:
+          type: string
+          description: "Patch operation. Supported operations: `replace`."
+        path:
+          type: string
+          description: "JSON path to operate on. Supported paths: `/debug`."
+        value:
+          type: object
+          description: "The new value for the operation. Type of value is dependent of `path`"

--- a/wazo_webhookd/plugins/config/http.py
+++ b/wazo_webhookd/plugins/config/http.py
@@ -22,4 +22,5 @@ class ConfigResource(AuthResource):
         config_patch = config_patch_schema.load(request.get_json(), many=True)
         config = self._config_service.get_config()
         patched_config = JsonPatch(config_patch).apply(config)
-        return self._config_service.update_config(patched_config)
+        self._config_service.update_config(patched_config)
+        return '', 204

--- a/wazo_webhookd/plugins/config/http.py
+++ b/wazo_webhookd/plugins/config/http.py
@@ -1,14 +1,25 @@
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from flask import request
 from wazo_webhookd.rest_api import AuthResource
 from xivo.auth_verifier import required_acl
+from jsonpatch import JsonPatch
+
+from .schemas import config_patch_schema
 
 
 class ConfigResource(AuthResource):
-    def __init__(self, config):
-        self._config = config
+    def __init__(self, config_service):
+        self._config_service = config_service
 
     @required_acl('webhookd.config.read')
     def get(self):
-        return dict(self._config), 200
+        return self._config_service.get_config(), 200
+
+    @required_acl('webhookd.config.update')
+    def patch(self):
+        config_patch = config_patch_schema.load(request.get_json(), many=True)
+        config = self._config_service.get_config()
+        patched_config = JsonPatch(config_patch).apply(config)
+        return self._config_service.update_config(patched_config)

--- a/wazo_webhookd/plugins/config/http.py
+++ b/wazo_webhookd/plugins/config/http.py
@@ -23,4 +23,4 @@ class ConfigResource(AuthResource):
         config = self._config_service.get_config()
         patched_config = JsonPatch(config_patch).apply(config)
         self._config_service.update_config(patched_config)
-        return '', 204
+        return self._config_service.get_config(), 200

--- a/wazo_webhookd/plugins/config/plugin.py
+++ b/wazo_webhookd/plugins/config/plugin.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .http import ConfigResource
+from .service import ConfigService
 
 
 class Plugin:
     def load(self, dependencies):
         api = dependencies['api']
         config = dependencies['config']
-        api.add_resource(ConfigResource, '/config', resource_class_args=[config])
+        config_service = ConfigService(config)
+        api.add_resource(
+            ConfigResource, '/config', resource_class_args=[config_service]
+        )

--- a/wazo_webhookd/plugins/config/schemas.py
+++ b/wazo_webhookd/plugins/config/schemas.py
@@ -1,0 +1,16 @@
+# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from marshmallow import Schema
+from marshmallow.validate import Equal
+
+from xivo.mallow import fields
+
+
+class ConfigPatchSchema(Schema):
+    op = fields.String(validate=Equal('replace'))
+    path = fields.String(validate=Equal('/debug'))
+    value = fields.Boolean()
+
+
+config_patch_schema = ConfigPatchSchema()

--- a/wazo_webhookd/plugins/config/service.py
+++ b/wazo_webhookd/plugins/config/service.py
@@ -7,7 +7,8 @@ import threading
 
 class ConfigService:
 
-    # share the lock between service instances
+    # Changing root logger log-level requires application-wide lock.
+    # This lock will be shared across all instances.
     _lock = threading.Lock()
 
     def __init__(self, config):

--- a/wazo_webhookd/plugins/config/service.py
+++ b/wazo_webhookd/plugins/config/service.py
@@ -1,0 +1,38 @@
+# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+import threading
+
+
+class ConfigService:
+
+    # share the lock between service instances
+    _lock = threading.Lock()
+
+    def __init__(self, config):
+        self._config = dict(config)
+        self._enabled = False
+
+    def get_config(self):
+        with self._lock:
+            return dict(self._config)
+
+    def update_config(self, config):
+        with self._lock:
+            self._update_debug(config['debug'])
+            self._config['debug'] = config['debug']
+
+    def _update_debug(self, debug):
+        if debug:
+            self._enable_debug()
+        else:
+            self._disable_debug()
+
+    def _enable_debug(self):
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.DEBUG)
+
+    def _disable_debug(self):
+        root_logger = logging.getLogger()
+        root_logger.setLevel(self._config['log_level'])


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-webhookd-client/pull/9

## integration tests: build dependent docker images sequentially

Why:

* When we need both images to be updated, the webhookd-test image will
be based on the older webhookd image

## docker: reduce context size

Why:

* Use docker cache even when unrelated files have changed = faster build

## add PATCH /config

Why:

* Enable/disable debug logs at runtime
