### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -68,7 +68,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def make_webhookd(cls, token, tenant=None, **kwargs):
         return WebhookdClient(
-            'localhost',
+            '127.0.0.1',
             cls.service_port(9300, 'webhookd'),
             prefix=None,
             https=False,
@@ -79,7 +79,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
 
     @classmethod
     def make_auth(cls):
-        return AuthClient('localhost', cls.service_port(9497, 'auth'))
+        return AuthClient('127.0.0.1', cls.service_port(9497, 'auth'))
 
     @classmethod
     def configured_wazo_auth(cls):
@@ -144,7 +144,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
 
     def make_bus(self):
         return BusClient.from_connection_fields(
-            host='localhost', port=self.service_port(5672, 'rabbitmq')
+            host='127.0.0.1', port=self.service_port(5672, 'rabbitmq')
         )
 
     def make_sentinel(self):
@@ -165,7 +165,7 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
             def reset(self):
                 requests.delete(self._url, verify=False)
 
-        url = 'http://localhost:{port}/1.0/sentinel'.format(
+        url = 'http://127.0.0.1:{port}/1.0/sentinel'.format(
             port=self.service_port(9300, 'webhookd')
         )
         return Sentinel(url)

--- a/integration_tests/suite/test_bus.py
+++ b/integration_tests/suite/test_bus.py
@@ -17,7 +17,7 @@ class TestBusConsumer(BaseIntegrationTest):
     def setUp(self):
         super().setUp()
         bus_port = self.service_port(5672, 'rabbitmq')
-        self.bus = BusClient.from_connection_fields(host='localhost', port=bus_port)
+        self.bus = BusClient.from_connection_fields(host='127.0.0.1', port=bus_port)
 
     def test_message_is_received(self):
         ping_event = {'name': 'webhookd_ping', 'data': {'payload': 'test-ping'}}

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -27,7 +27,7 @@ from wazo_webhookd.database.models import SubscriptionOption
 from wazo_webhookd.database.purger import SubscriptionLogsPurger
 from wazo_webhookd.plugins.subscription.service import SubscriptionService
 
-DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@localhost:{port}')
+DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@127.0.0.1:{port}')
 
 
 class TestDatabase(AssetLaunchingTestCase):

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -21,6 +21,6 @@ class TestDocumentation(BaseIntegrationTest):
 
     def test_documentation_errors(self):
         port = self.service_port(9300, 'webhookd')
-        api_url = 'http://localhost:{port}/1.0/api/api.yml'.format(port=port)
+        api_url = 'http://127.0.0.1:{port}/1.0/api/api.yml'.format(port=port)
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/suite/test_http_callback.py
+++ b/integration_tests/suite/test_http_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 import operator
 import time
@@ -153,7 +153,7 @@ class TestHTTPCallback(BaseIntegrationTest):
     def setUp(self):
         super().setUp()
         self.third_party = MockServerClient(
-            'http://localhost:{port}'.format(
+            'http://127.0.0.1:{port}'.format(
                 port=self.service_port(1080, 'third-party-http')
             )
         )

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -82,7 +82,7 @@ class TestMobileCallback(BaseIntegrationTest):
 
     def test_workflow_fcm(self):
         third_party = MockServerClient(
-            'http://localhost:{port}'.format(
+            'http://127.0.0.1:{port}'.format(
                 port=self.service_port(443, 'fcm.googleapis.com')
             )
         )
@@ -185,7 +185,7 @@ class TestMobileCallback(BaseIntegrationTest):
         auth.set_external_auth({'token': 'token-android', 'apns_token': 'token-ios'})
 
         apns_third_party = MockServerClient(
-            'http://localhost:{port}'.format(
+            'http://127.0.0.1:{port}'.format(
                 port=self.service_port(1080, 'third-party-http')
             )
         )
@@ -309,7 +309,7 @@ class TestMobileCallback(BaseIntegrationTest):
         )
 
         apns_third_party = MockServerClient(
-            'http://localhost:{port}'.format(
+            'http://127.0.0.1:{port}'.format(
                 port=self.service_port(1080, 'third-party-http')
             )
         )


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6