### PR TITLE
Pull request for set-alembic-db-env

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -13,9 +13,6 @@ script_location = alembic
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://asterisk:proformatique@localhost/asterisk
-
-
 # Logging configuration
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
-
-from alembic import context
-from sqlalchemy import engine_from_config, pool
+import os
 from logging.config import fileConfig
+from alembic import context
+from sqlalchemy import create_engine
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -17,6 +16,19 @@ fileConfig(config.config_file_name)
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
+VERSION_TABLE = 'alembic_version_webhookd'
+URI = os.getenv('ALEMBIC_DB_URI', None)
+
+
+def get_url():
+    # The import should not be top level to allow the usage of the ALEMBIC_DB_URI
+    # environment variable when the DB is not hosted on the same host as wazo-webhookd.
+    # When building the docker image for the database for example.
+    from wazo_webhookd.config import load_config
+
+    wazo_config = load_config('')
+    return wazo_config.get('db_uri')
+
 
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
@@ -30,8 +42,8 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, version_table='alembic_version_webhookd')
+    url = URI or config.get_main_option("sqlalchemy.url") or get_url()
+    context.configure(url=url, version_table=VERSION_TABLE)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -44,14 +56,12 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    engine = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix='sqlalchemy.',
-        poolclass=pool.NullPool,
-    )
+
+    url = URI or config.get_main_option("sqlalchemy.url") or get_url()
+    engine = create_engine(url)
 
     connection = engine.connect()
-    context.configure(connection=connection, version_table='alembic_version_webhookd')
+    context.configure(connection=connection, version_table=VERSION_TABLE)
 
     try:
         with context.begin_transaction():

--- a/contribs/docker/Dockerfile-db
+++ b/contribs/docker/Dockerfile-db
@@ -1,12 +1,16 @@
 FROM wazoplatform/wazo-base-db
-MAINTAINER Wazo Maintainers <dev@wazo.community>
+LABEL maintainer="Wazo Maintainers <dev@wazo.community>"
 
-ADD . /usr/src/wazo-webhookd
+COPY . /usr/src/wazo-webhookd
 WORKDIR /usr/src/wazo-webhookd
+ENV ALEMBIC_DB_URI postgresql://wazo-webhookd:Secr7t@localhost/wazo-webhookd
+
 RUN true \
     && python3 setup.py install \
     && pg_start \
-    && wazo-webhookd-init-db --user postgres \
+    && su postgres -c "psql -c \"CREATE ROLE \\"'"'"wazo-webhookd\\"'"'" LOGIN PASSWORD 'Secr7t';\"" \
+    && su postgres -c "psql -c 'CREATE DATABASE \"wazo-webhookd\" WITH OWNER \"wazo-webhookd\";'" \
+    && su postgres -c "psql \"wazo-webhookd\" -c 'CREATE EXTENSION \"uuid-ossp\";'" \
     && (cd /usr/src/wazo-webhookd && python3 -m alembic.config -c alembic.ini upgrade head) \
     && pg_stop \
     && true

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -14,6 +14,6 @@ webhookd-test: webhookd egg-info
 	docker build --no-cache -t wazo-webhookd-test -f Dockerfile ..
 
 db:
-	docker build -f ../contribs/docker/Dockerfile-db -t wazoplatform/wazo-webhookd-db ..
+	docker build -f ../contribs/docker/Dockerfile-db -t wazoplatform/wazo-webhookd-db:local ..
 
 .PHONY: test-setup test egg-info webhookd webhookd-test db

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "443"
 
   postgres:
-    image: wazoplatform/wazo-webhookd-db
+    image: wazoplatform/wazo-webhookd-db:local
     ports:
       - "5432"
 

--- a/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default-config.yml
+++ b/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default-config.yml
@@ -2,7 +2,7 @@ rest_api:
   listen: 0.0.0.0
 auth:
   host: auth
-db_uri: postgresql://asterisk:proformatique@postgres/asterisk
+db_uri: postgresql://wazo-webhookd:Secr7t@postgres/wazo-webhookd
 bus:
   host: rabbitmq
 celery:

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -27,7 +27,7 @@ from wazo_webhookd.database.models import SubscriptionOption
 from wazo_webhookd.database.purger import SubscriptionLogsPurger
 from wazo_webhookd.plugins.subscription.service import SubscriptionService
 
-DB_URI = os.getenv('DB_URI', 'postgresql://asterisk:proformatique@127.0.0.1:{port}')
+DB_URI = os.getenv('DB_URI', 'postgresql://wazo-webhookd:Secr7t@127.0.0.1:{port}')
 
 
 class TestDatabase(AssetLaunchingTestCase):

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -127,7 +127,7 @@ def _parse_cli_args(args):
         help='Log debug mesages. Override log_level',
     )
     parser.add_argument('-u', '--user', action='store', help='The owner of the process')
-    parsed_args = parser.parse_args()
+    parsed_args = parser.parse_args(args)
 
     result = {}
     if parsed_args.config_file:


### PR DESCRIPTION
## refactor alembic env to use env + default config

why: to be like other services and be able to run alembic script without
importing all webhookd code (when using env var)

## test: add local tag to image

why: all integration tests start with a docker-compose pull. But pulling
will always take the image from hub, even if the host has more recent
version. This behavior is new because we recently push the db image on
hub