### PR TITLE
pin markupsafe version to buster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ itsdangerous==0.24  # from flask
 jinja2==2.10
 jsonpatch==1.21
 kombu==4.6.11
+markupsafe==1.1.0  # from flask
 marshmallow==3.0.0b14
 netifaces==0.10.4
 psycopg2==2.7.7

--- a/wazo_webhookd/plugins/subscription/celery_tasks.py
+++ b/wazo_webhookd/plugins/subscription/celery_tasks.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 import datetime
 import logging
@@ -82,7 +82,7 @@ def hook_runner_task(task, hook_uuid, ep_name, config, subscription, event):
         if task.request.retries + 1 >= config["hook_max_attempts"]:
             return
 
-        retry_backoff = int(2 ** task.request.retries)
+        retry_backoff = int(2**task.request.retries)
         task.retry(countdown=retry_backoff)
     except Exception as e:
         if isinstance(e, HookExpectedError):


### PR DESCRIPTION
why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 and jinja2 from buster