### PR TITLE
WAZO-2753-avoid-displaying-notifications-on-android

### DIFF
--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -231,7 +231,8 @@ class PushNotification:
         if channel_id == 'wazo-notification-call':
             notify_kwargs['extra_notification_kwargs'] = {'priority': 'high'}
         else:
-            notify_kwargs['badge'] = 1
+            if channel_id != 'wazo-notification-cancel-call':
+                notify_kwargs['badge'] = 1
             notify_kwargs['extra_notification_kwargs'] = {
                 'android_channel_id': channel_id
             }
@@ -240,7 +241,10 @@ class PushNotification:
             if message_body:
                 notify_kwargs['message_body'] = message_body
 
-        notification = push_service.notify_single_device(**notify_kwargs)
+        if channel_id != 'wazo-notification-cancel-call':
+            notification = push_service.notify_single_device(**notify_kwargs)
+        else:
+            notification = push_service.single_device_data_message(**notify_kwargs)
         if notification.get('failure') != 0:
             logger.error('Error to send push notification: %s', notification)
         return notification

--- a/wazo_webhookd/services/mobile/tests/test_fcm.py
+++ b/wazo_webhookd/services/mobile/tests/test_fcm.py
@@ -1,0 +1,105 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0+
+
+from unittest import TestCase
+from unittest.mock import patch, Mock, sentinel as s
+
+from ..plugin import PushNotification
+
+
+class TestSendViaFcm(TestCase):
+    def setUp(self):
+        task = Mock()
+        config = Mock()
+        external_tokens = {'token': s.token}
+        external_config = {'fcm_api_key': s.fcm_api_key}
+        jwt = Mock()
+
+        self.push_notification = PushNotification(
+            task,
+            config,
+            external_tokens,
+            external_config,
+            jwt,
+        )
+
+    @patch('wazo_webhookd.services.mobile.plugin.FCMNotification')
+    def test_send_incoming_call(self, FCMNotification):
+        push_service = FCMNotification.return_value
+
+        title = 'Incoming Call'  # Ignored
+        body = 'From: 5555555555'  # Ignored
+        channel_id = 'wazo-notification-call'
+        data = s.incoming_call_data
+
+        self.push_notification._send_via_fcm(title, body, channel_id, data)
+
+        push_service.single_device_data_message.assert_not_called()
+        push_service.notify_single_device.assert_called_once_with(
+            registration_id=s.token,
+            data_message=s.incoming_call_data,
+            extra_notification_kwargs={'priority': 'high'},
+        )
+
+    @patch('wazo_webhookd.services.mobile.plugin.FCMNotification')
+    def test_send_incoming_call_cancel(self, FCMNotification):
+        push_service = FCMNotification.return_value
+
+        title = None  # Ignored
+        body = None  # Ignored
+        channel_id = 'wazo-notification-cancel-call'
+        data = s.cancel_incoming_call_data
+
+        self.push_notification._send_via_fcm(title, body, channel_id, data)
+
+        push_service.single_device_data_message.assert_called_once_with(
+            registration_id=s.token,
+            data_message=s.cancel_incoming_call_data,
+            extra_notification_kwargs={'android_channel_id': channel_id},
+        )
+        push_service.notify_single_device.assert_not_called()
+
+    @patch('wazo_webhookd.services.mobile.plugin.FCMNotification')
+    def test_send_voicemail_received(self, FCMNotification):
+        push_service = FCMNotification.return_value
+
+        title = 'New voicemail'
+        body = 'From: 5555555555'
+        channel_id = 'wazo-notification-voicemail'
+        data = s.voicemail_data
+
+        self.push_notification._send_via_fcm(title, body, channel_id, data)
+
+        push_service.single_device_data_message.assert_not_called()
+        push_service.notify_single_device.assert_called_once_with(
+            registration_id=s.token,
+            data_message=s.voicemail_data,
+            message_title='New voicemail',
+            message_body='From: 5555555555',
+            badge=1,
+            extra_notification_kwargs={'android_channel_id': channel_id},
+        )
+
+    @patch('wazo_webhookd.services.mobile.plugin.FCMNotification')
+    def test_send_chat_received(self, FCMNotification):
+        push_service = FCMNotification.return_value
+
+        data = {
+            'alias': s.chat_alias,
+            'content': s.chat_content,
+        }
+        title = s.chat_alias
+        body = s.chat_content
+        channel_id = 'wazo-notification-chat'
+
+        self.push_notification._send_via_fcm(title, body, channel_id, data)
+
+        push_service.single_device_data_message.assert_not_called()
+        push_service.notify_single_device.assert_called_once_with(
+            registration_id=s.token,
+            data_message=data,
+            message_title=s.chat_alias,
+            message_body=s.chat_content,
+            badge=1,
+            extra_notification_kwargs={'android_channel_id': channel_id},
+        )


### PR DESCRIPTION
During a cancel push notification we do not want the user to view the notification. In order to do that we have to use `single_device_data_message` instead of `notify_single_device`.

I also tried to group the logic for each different use cases to avoid having multiple `if`s in the function with the same condition