### PR TITLE
disable consul/service_discovery by default

### DIFF
--- a/debian/wazo-webhookd.links
+++ b/debian/wazo-webhookd.links
@@ -1,2 +1,0 @@
-/var/lib/consul/default_xivo_consul_config.yml /etc/wazo-webhookd/conf.d/050-xivo-consul-config.yml
-/var/lib/consul/default_xivo_consul_token.yml /etc/wazo-webhookd/conf.d/050-xivo-consul-token.yml

--- a/etc/wazo-webhookd/config.yml
+++ b/etc/wazo-webhookd/config.yml
@@ -77,12 +77,12 @@ mobile_apns_port: 443
 service_discovery:
   enabled: false
 
-# Example of service discovery settings
+# Example settings to enable service discovery
 #
 # Necessary to use service discovery
 # consul:
 #   scheme: http
-#   host: localhost
+#   host: consul.example.com
 #   port: 8500
 #   token: 'the_one_ring'
 #

--- a/etc/wazo-webhookd/config.yml
+++ b/etc/wazo-webhookd/config.yml
@@ -35,13 +35,6 @@ celery:
     worker_min: 3
     worker_max: 5
 
-# Consul connection settings
-consul:
-  scheme: http
-  host: localhost
-  port: 8500
-  token: 'the_one_ring'
-
 # Database connection settings
 db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-webhookd
 
@@ -65,28 +58,6 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-# Service discovery configuration. all time intervals are in seconds
-service_discovery:
-  # Indicates whether of not to use service discovery.
-  # It should only be disabled for testing purposes
-  enabled: true
-  # The address that will be received by other services using service discovery.
-  # Use "advertise_address: auto" to enable ip address detection based on
-  # advertise_address_interface
-  advertise_address: auto
-  # If advertise_address is "auto" this interface will be used to find the ip
-  # address to advertise. Ignored otherwise
-  advertise_address_interface: eth0
-  advertise_port: 9300
-  # The number of seconds that consul will wait between 2 ttl messages to mark
-  # this service as up
-  ttl_interval: 30
-  # The time interval before the service sends a new ttl message to consul
-  refresh_interval: 27
-  # The time interval to detect that the service is running when starting
-  retry_interval: 2
-  extra_tags: []
-
 enabled_plugins:
   api: true
   config: true
@@ -102,3 +73,36 @@ mobile_apns_call_topic: org.wazo-platform.voip
 mobile_apns_default_topic:  org.wazo-platform
 mobile_apns_host: api.push.apple.com
 mobile_apns_port: 443
+
+service_discovery:
+  enabled: false
+
+# Example of service discovery settings
+#
+# Necessary to use service discovery
+# consul:
+#   scheme: http
+#   host: localhost
+#   port: 8500
+#   token: 'the_one_ring'
+#
+# # All time intervals are in seconds
+# service_discovery:
+#   # Indicates whether of not to use service discovery.
+#   enabled: true
+#   # The address that will be received by other services using service discovery.
+#   # Use "advertise_address: auto" to enable ip address detection based on
+#   # advertise_address_interface
+#   advertise_address: auto
+#   # If advertise_address is "auto" this interface will be used to find the ip
+#   # address to advertise. Ignored otherwise
+#   advertise_address_interface: eth0
+#   advertise_port: 9300
+#   # The number of seconds that consul will wait between 2 ttl messages to mark
+#   # this service as up
+#   ttl_interval: 30
+#   # The time interval before the service sends a new ttl message to consul
+#   refresh_interval: 27
+#   # The time interval to detect that the service is running when starting
+#   retry_interval: 2
+#   extra_tags: []

--- a/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default.yml
@@ -11,6 +11,4 @@ celery:
   broker: amqp://guest:guest@rabbitmq:5672
 enabled_plugins:
   sentinel: True
-service_discovery:
-  enabled: false
 hook_max_attempts: 3

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -43,7 +43,6 @@ _DEFAULT_CONFIG = {
         'worker_min': 3,
         'worker_max': 5,
     },
-    'consul': {'scheme': 'http', 'host': 'localhost', 'port': 8500},
     'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-webhookd',
     'rest_api': {
         'listen': '127.0.0.1',
@@ -55,11 +54,15 @@ _DEFAULT_CONFIG = {
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
     },
+    'consul': {
+        'scheme': 'http',
+        'port': 8500,
+    },
     'service_discovery': {
+        'enabled': False,
         'advertise_address': 'auto',
         'advertise_address_interface': 'eth0',
         'advertise_port': _DEFAULT_HTTP_PORT,
-        'enabled': True,
         'ttl_interval': 30,
         'refresh_interval': 27,
         'retry_interval': 2,


### PR DESCRIPTION
why: consul is not used in default install
- Remove host key from default consul setting to block service start if
  not defined
- Keep common service_discovery and consul key in config.py to avoid
  to redefine everything when using these settings