### PR TITLE
debian: fix xivo-bus dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Depends:
  wazo-auth-client-python3,
  wazo-dbms,
  xivo-lib-python-python3,
- xivo-bus
+ xivo-bus-python3
 Description: Wazo webhookd server
  Wazo is a system based on a powerful IPBX, to bring an easy to
  install solution for telephony and related services.


### PR DESCRIPTION
why: repo always has been in python3, but this dependency has been
copy/paste and it was in python2