### PR TITLE
debian: pin sqlalchemy-utils to prevent upgrade traceback

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Depends:
  python3-pyfcm,
  python3-setproctitle,
  python3-sqlalchemy,
- python3-sqlalchemy-utils,
+ python3-sqlalchemy-utils (>= 0.36.8),
  python3-stevedore,
  python3-yaml,
  python3-werkzeug,


### PR DESCRIPTION
why: When upgrading from Buster to Bullseye, sqlalchemy-utils is
upgraded after wazo services. So if the service use new method, it will
raise an error and fail the installation of this package.

Fortunally, on most case, the command after is dist-upgrade and
will fix thing. But it's still worrying for a sysadmin