### PR TITLE
Remove event that stopped token renewer after first renewal

### DIFF
--- a/wazo_webhookd/controller.py
+++ b/wazo_webhookd/controller.py
@@ -50,9 +50,6 @@ class Controller:
             self._token_renewer.subscribe_to_next_token_details_change(
                 auth.init_master_tenant
             )
-        self._token_renewer.subscribe_to_next_token_details_change(
-            lambda t: self._token_renewer.emit_stop()
-        )
         self._token_renewer.subscribe_to_token_change(self._auth_client.set_token)
         self._bus_consumer = BusConsumer(name='wazo_webhookd', **config['bus'])
         self.rest_api = CoreRestApi(config)

--- a/wazo_webhookd/plugins/mobile/celery_tasks.py
+++ b/wazo_webhookd/plugins/mobile/celery_tasks.py
@@ -43,7 +43,7 @@ def send_notification(
             jwt,
         ) = PushNotificationService.get_external_data(config, notification['user_uuid'])
     except requests.HTTPError as e:
-        if e.response.status_code == 404:
+        if e.response and e.response.status_code == 404:
             logger.error(
                 'Cannot send notification as no authentication exists for mobile (%s)',
                 str(e),


### PR DESCRIPTION
reason: It is needed now and this breaks things by preventing the token from being renewed properly