### PR TITLE
mobile: improve android push notif delivery time

### DIFF
--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -384,6 +384,7 @@ class PushNotification:
         notify_kwargs = {
             'registration_id': self.external_tokens['token'],
             'data_message': data,
+            'time_to_live': 0,
         }
 
         notification_type = data['notification_type']

--- a/wazo_webhookd/services/mobile/tests/test_fcm.py
+++ b/wazo_webhookd/services/mobile/tests/test_fcm.py
@@ -49,6 +49,7 @@ class TestSendViaFcm(TestCase):
         push_service.notify_single_device.assert_called_once_with(
             registration_id=s.token,
             data_message=data,
+            time_to_live=0,
             extra_notification_kwargs={'priority': 'high'},
         )
 
@@ -70,6 +71,7 @@ class TestSendViaFcm(TestCase):
         push_service.single_device_data_message.assert_called_once_with(
             registration_id=s.token,
             data_message=data,
+            time_to_live=0,
             extra_notification_kwargs={
                 'android_channel_id': DEFAULT_ANDROID_CHANNEL_ID
             },
@@ -95,6 +97,7 @@ class TestSendViaFcm(TestCase):
         push_service.notify_single_device.assert_called_once_with(
             registration_id=s.token,
             data_message=data,
+            time_to_live=0,
             message_title='New voicemail',
             message_body='From: 5555555555',
             badge=1,
@@ -124,6 +127,7 @@ class TestSendViaFcm(TestCase):
         push_service.notify_single_device.assert_called_once_with(
             registration_id=s.token,
             data_message=data,
+            time_to_live=0,
             message_title=s.chat_alias,
             message_body=s.chat_content,
             badge=1,
@@ -165,5 +169,6 @@ class TestSendViaFcm(TestCase):
         push_service.notify_single_device.assert_called_once_with(
             registration_id=s.token,
             data_message=data,
+            time_to_live=0,
             extra_notification_kwargs={'priority': 'high'},
         )


### PR DESCRIPTION
Why:

* the time_to_live = 0 header makes FCM not store the notification and
  deliver it immediately if an app is registered for it else drop the
  notification