### PR TITLE
mypy: use default import following policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
         language_version: "3.10"
         args: [--explicit-package-bases]
         additional_dependencies:
+          - "alembic"
           - "sqlalchemy-stubs"
           - "sqlalchemy==1.3.22"
           - "types-pyyaml"

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -14,7 +14,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+if config.config_file_name:
+    fileConfig(config.config_file_name)
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ python_version = "3.10"
 show_error_codes = true
 check_untyped_defs = true
 warn_unused_configs = true
-follow_imports = "skip"
 ignore_missing_imports = true
 
 [tool.black]


### PR DESCRIPTION
Why:

* This option makes pre-commit miss some typing errors