### PR TITLE
Pull request for flaky-integration-tests

### DIFF
--- a/integration_tests/suite/test_http_callback.py
+++ b/integration_tests/suite/test_http_callback.py
@@ -781,6 +781,14 @@ class TestHTTPCallback(BaseIntegrationTest):
 
         webhookd = self.make_webhookd(MASTER_TOKEN)
 
+        def all_logs_in_db():
+            logs = webhookd.subscriptions.get_logs(subscription["uuid"])
+            assert_that(logs['total'], equal_to(5), logs)
+
+        until.assert_(
+            all_logs_in_db, message='Some logs are not visible in the API', timeout=5
+        )
+
         # Default order
         logs = webhookd.subscriptions.get_logs(subscription["uuid"])
         assert_that(logs['total'], equal_to(5))

--- a/integration_tests/suite/test_http_callback.py
+++ b/integration_tests/suite/test_http_callback.py
@@ -3,7 +3,14 @@
 import operator
 import time
 
-from hamcrest import assert_that, contains, contains_string, equal_to, has_entries, is_
+from hamcrest import (
+    assert_that,
+    contains_exactly,
+    contains_string,
+    equal_to,
+    has_entries,
+    is_,
+)
 from mockserver import MockServerClient
 from wazo_test_helpers import until
 
@@ -195,7 +202,9 @@ class TestHTTPCallback(BaseIntegrationTest):
         webhookd = self.make_webhookd(MASTER_TOKEN)
         logs = webhookd.subscriptions.get_logs(subscription["uuid"])
         assert_that(logs['total'], equal_to(1))
-        assert_that(logs['items'], contains(has_entries(status="success", attempts=1)))
+        assert_that(
+            logs['items'], contains_exactly(has_entries(status="success", attempts=1))
+        )
 
     @subscription(TEST_SUBSCRIPTION)
     def test_given_one_http_subscription_when_bus_event_then_one_http_callback_with_json(
@@ -227,7 +236,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(1))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(
                     status="success", detail=has_entries(response_body=body), attempts=1
                 )
@@ -262,7 +271,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(1))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(
                     status="error",
                     detail=has_entries(error=contains_string("Gone")),
@@ -303,7 +312,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(2))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(
                     status="failure",
                     detail=has_entries(error=contains_string("Service Unavailable")),
@@ -560,7 +569,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(1))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(
                     status="success",
                     detail=has_entries(request_body='trigger value'),
@@ -794,7 +803,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(5))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(status="success"),
                 has_entries(status="failure"),
                 has_entries(status="success"),
@@ -812,7 +821,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(5))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(status="failure"),
                 has_entries(status="failure"),
                 has_entries(status="success"),
@@ -828,14 +837,14 @@ class TestHTTPCallback(BaseIntegrationTest):
             subscription["uuid"], limit=2, direction="asc"
         )
         assert_that(logs['total'], equal_to(2))
-        assert_that(logs['items'], contains(*all_sorted_items[:2]))
+        assert_that(logs['items'], contains_exactly(*all_sorted_items[:2]))
 
         # limit 2 and offset 2
         logs = webhookd.subscriptions.get_logs(
             subscription["uuid"], limit=2, offset=2, direction="asc"
         )
         assert_that(logs['total'], equal_to(2))
-        assert_that(logs['items'], contains(*all_sorted_items[2:4]))
+        assert_that(logs['items'], contains_exactly(*all_sorted_items[2:4]))
 
         # limit 2, offset 2 and from_date
         logs = webhookd.subscriptions.get_logs(
@@ -846,14 +855,14 @@ class TestHTTPCallback(BaseIntegrationTest):
             direction="asc",
         )
         assert_that(logs['total'], equal_to(2))
-        assert_that(logs['items'], contains(*all_sorted_items[3:5]))
+        assert_that(logs['items'], contains_exactly(*all_sorted_items[3:5]))
 
         # by status
         logs = webhookd.subscriptions.get_logs(subscription["uuid"], order="status")
         assert_that(logs['total'], equal_to(5))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(status="failure"),
                 has_entries(status="failure"),
                 has_entries(status="failure"),
@@ -899,7 +908,7 @@ class TestHTTPCallback(BaseIntegrationTest):
         assert_that(logs['total'], equal_to(3))
         assert_that(
             logs['items'],
-            contains(
+            contains_exactly(
                 has_entries(status="error"),
                 has_entries(status="failure"),
                 has_entries(status="failure"),

--- a/integration_tests/suite/test_subscriptions.py
+++ b/integration_tests/suite/test_subscriptions.py
@@ -5,7 +5,7 @@ from typing import Any
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_entries,
@@ -111,7 +111,9 @@ class TestListSubscriptions(BaseIntegrationTest):
 
         assert_that(
             response,
-            has_entries({'items': contains(has_entries(**subscription_)), 'total': 1}),
+            has_entries(
+                {'items': contains_exactly(has_entries(**subscription_)), 'total': 1}
+            ),
         )
 
     @subscription(TEST_SUBSCRIPTION)
@@ -127,7 +129,9 @@ class TestListSubscriptions(BaseIntegrationTest):
 
         assert_that(
             response,
-            has_entries({'items': contains(has_entries(**TEST_SUBSCRIPTION_METADATA))}),
+            has_entries(
+                {'items': contains_exactly(has_entries(**TEST_SUBSCRIPTION_METADATA))}
+            ),
         )
 
 
@@ -147,7 +151,10 @@ class TestListUserSubscriptions(BaseIntegrationTest):
         assert_that(
             response,
             has_entries(
-                {'items': contains(has_entries(**user_subscription)), 'total': 1}
+                {
+                    'items': contains_exactly(has_entries(**user_subscription)),
+                    'total': 1,
+                }
             ),
         )
 


### PR DESCRIPTION
## integration tests: fix flakyness

Why:

* Sometimes the logs take a bit more time to get committed to the DB

## integration tests: remove deprecation warnings