### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jinja2==3.0.3  # from flask
 jsonpatch==1.25
 kombu==5.0.2  # from wazo-bus
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 netifaces==0.10.9
 psycopg2-binary==2.8.6
 pyfcm==1.4.7

--- a/wazo_webhookd/plugins/mobile/schema.py
+++ b/wazo_webhookd/plugins/mobile/schema.py
@@ -38,7 +38,7 @@ class NotificationSchema(Schema):
     # The only technical limit on the payload is a max total size of 2KB.
     title = fields.String(validate=Length(max=128), required=True)
     body = fields.String(validate=Length(max=250), required=True)
-    extra = fields.Dict(missing=dict, default=dict)
+    extra = fields.Dict(load_default=dict, dump_default=dict)
 
 
 notification_schema = NotificationSchema()

--- a/wazo_webhookd/plugins/subscription/schema.py
+++ b/wazo_webhookd/plugins/subscription/schema.py
@@ -128,10 +128,10 @@ class SubscriptionSchema(Schema):
         allow_none=False,
         required=True,
     )
-    events_user_uuid = fields.String(validate=Length(equal=36), missing=None)
-    events_wazo_uuid = fields.String(validate=Length(equal=36), missing=None)
+    events_user_uuid = fields.String(validate=Length(equal=36), load_default=None)
+    events_wazo_uuid = fields.String(validate=Length(equal=36), load_default=None)
     config = ConfigField(allow_none=False, required=True)
-    owner_user_uuid = fields.String(validate=Length(equal=36), missing=None)
+    owner_user_uuid = fields.String(validate=Length(equal=36), load_default=None)
     owner_tenant_uuid = fields.UUID(dump_only=True)
     # TODO(sileht): We should also add an events_tenant_uuid to filter
     # event on tenant_uuid. Currently if I have the
@@ -157,7 +157,7 @@ class UserSubscriptionSchema(Schema):
 
 class SubscriptionListParamsSchema(Schema):
     search_metadata = fields.Dict()
-    recurse = fields.Boolean(missing=False)
+    recurse = fields.Boolean(load_default=False)
 
     @pre_load
     def aggregate_search_metadata(self, data, **kwargs):


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade