### PR TITLE
use StatusAggregator for /status

### DIFF
--- a/integration_tests/Dockerfile
+++ b/integration_tests/Dockerfile
@@ -15,6 +15,9 @@ RUN python3 -m pip install -e .
 WORKDIR /usr/src/wazo-webhookd/integration_tests/plugins/celery_task_plugin
 RUN python3 -m pip install -e .
 
+WORKDIR /usr/src/wazo-webhookd/integration_tests/plugins/status_sentinel
+RUN python3 -m pip install -e .
+
 RUN cat /usr/src/wazo-webhookd/integration_tests/assets/ssl/mockserver/mockserver.crt >> /opt/venv/lib/python3.11/site-packages/certifi/cacert.pem
 RUN cat /usr/src/wazo-webhookd/integration_tests/assets/fake-apple-ca/certs/server.crt >> /opt/venv/lib/python3.11/site-packages/certifi/cacert.pem
 

--- a/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default.yml
@@ -12,6 +12,7 @@ celery:
 enabled_plugins:
   sentinel: True
   celery_task_sentinel: True
+  status_sentinel: True
 enabled_celery_tasks:
   celery_task_sentinel: True
 hook_max_attempts: 5

--- a/integration_tests/plugins/status_sentinel/setup.py
+++ b/integration_tests/plugins/status_sentinel/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from setuptools import find_packages, setup
+
+setup(
+    name='wazo-webhookd-status-sentinel',
+    version='1.0',
+    author='Wazo Authors',
+    author_email='dev@wazo.community',
+    packages=find_packages(),
+    entry_points={
+        'wazo_webhookd.plugins': [
+            'status_sentinel = wazo_webhookd_status_sentinel.plugin:Plugin'
+        ]
+    },
+)

--- a/integration_tests/plugins/status_sentinel/wazo_webhookd_status_sentinel/plugin.py
+++ b/integration_tests/plugins/status_sentinel/wazo_webhookd_status_sentinel/plugin.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from xivo.status import Status
+
+
+def _provide_test_status(status):
+    status['test_component']['status'] = Status.ok
+
+
+class Plugin:
+    def load(self, dependencies):
+        status_aggregator = dependencies['status_aggregator']
+        status_aggregator.add_provider(_provide_test_status)

--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to, has_entries
@@ -52,6 +52,24 @@ class TestStatusAllOK(BaseIntegrationTest):
             )
 
         until.assert_(all_connections_ok, timeout=20)
+
+
+class TestStatusPluginProvider(BaseIntegrationTest):
+    asset = 'base'
+    wait_strategy = EverythingOkWaitStrategy()
+
+    def test_plugin_status_provider_appears_in_response(self):
+        webhookd = self.make_webhookd(MASTER_TOKEN)
+
+        result = webhookd.status.get()
+        assert_that(
+            result,
+            has_entries(
+                bus_consumer=has_entries(status='ok'),
+                master_tenant=has_entries(status='ok'),
+                test_component=has_entries(status='ok'),
+            ),
+        )
 
 
 class TestStatusNoMasterTenant(BaseIntegrationTest):

--- a/wazo_webhookd/bus.py
+++ b/wazo_webhookd/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -13,10 +13,12 @@ import kombu
 from wazo_bus.base import Base
 from wazo_bus.mixins import ConsumerMixin, ThreadableMixin
 from wazo_bus.publisher import BusPublisher as BasePublisher
+from xivo.status import Status
 
 if TYPE_CHECKING:
     from amqp import Message
     from kombu.transport.base import StdChannel
+    from xivo.status import StatusDict
 
     Payload = dict[str, Any]
     Headers = dict[str, Any]
@@ -165,6 +167,11 @@ class BusConsumer(ThreadableMixin, _ConsumerMixin, Base):
             callback, events, _ = self._handlers.pop(uuid)
         for event in events:
             self.unsubscribe(event, callback)
+
+    def provide_status(self, status: StatusDict) -> None:
+        status['bus_consumer']['status'] = (
+            Status.ok if self.consumer_connected() else Status.fail
+        )
 
     @classmethod
     def from_config(cls, bus_config):

--- a/wazo_webhookd/controller.py
+++ b/wazo_webhookd/controller.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from wazo_auth_client import Client as AuthClient
 from xivo import plugin_helpers
 from xivo.consul_helpers import ServiceCatalogRegistration
+from xivo.status import StatusAggregator
 from xivo.token_renewer import TokenRenewer
 
 from wazo_webhookd import celery
@@ -56,6 +57,7 @@ class Controller:
         self._bus_consumer = BusConsumer.from_config(config['bus'])
         self._bus_publisher = BusPublisher.from_config(config['uuid'], config['bus'])
         self.rest_api = CoreRestApi(config)
+        self.status_aggregator = StatusAggregator()
         self._service_manager = plugin_helpers.load(
             namespace='wazo_webhookd.services',
             names=config['enabled_services'],
@@ -65,6 +67,7 @@ class Controller:
                 'bus_publisher': self._bus_publisher,
                 'config': config,
                 'auth_client': self._auth_client,
+                'status_aggregator': self.status_aggregator,
                 'token_change_subscribe': self._token_renewer.subscribe_to_token_change,
             },
         )
@@ -77,6 +80,7 @@ class Controller:
                 'bus_consumer': self._bus_consumer,
                 'bus_publisher': self._bus_publisher,
                 'config': config,
+                'status_aggregator': self.status_aggregator,
                 'service_manager': self._service_manager,
                 'next_token_change_subscribe': self._token_renewer.subscribe_to_next_token_change,
             },

--- a/wazo_webhookd/plugins/status/api.yml
+++ b/wazo_webhookd/plugins/status/api.yml
@@ -18,6 +18,8 @@ definitions:
         $ref: '#/definitions/ComponentWithStatus'
       master_tenant:
         $ref: '#/definitions/ComponentWithStatus'
+    additionalProperties:
+      $ref: '#/definitions/ComponentWithStatus'
   ComponentWithStatus:
     type: object
     properties:

--- a/wazo_webhookd/plugins/status/http.py
+++ b/wazo_webhookd/plugins/status/http.py
@@ -1,47 +1,22 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, TypedDict, cast
+from typing import TYPE_CHECKING
 
 from xivo.auth_verifier import required_acl
 
-from wazo_webhookd import auth
 from wazo_webhookd.rest_api import AuthResource
 
 if TYPE_CHECKING:
-    from ...bus import BusConsumer
-    from ...types import WebhookdConfigDict
-
-
-class StatusDict(TypedDict):
-    status: Literal['ok', 'fail']
-
-
-class StatusResponse(TypedDict):
-    bus_consumer: StatusDict
-    master_tenant: StatusDict
+    from xivo.status import StatusAggregator
 
 
 class StatusResource(AuthResource):
-    def __init__(self, bus_consumer: BusConsumer, config: WebhookdConfigDict) -> None:
-        self._bus_consumer = bus_consumer
-        self._config = config
+    def __init__(self, status_aggregator: StatusAggregator) -> None:
+        self._status_aggregator = status_aggregator
 
     @required_acl('webhookd.status.read')
-    def get(self) -> tuple[StatusResponse, int]:
-        try:
-            auth.get_master_tenant_uuid()
-        except auth.MasterTenantNotInitializedException:
-            master_tenant_status = 'fail'
-        else:
-            master_tenant_status = 'ok'
-
-        result = {
-            'bus_consumer': {
-                'status': 'ok' if self._bus_consumer.consumer_connected() else 'fail'
-            },
-            'master_tenant': {'status': master_tenant_status},
-        }
-        return cast(StatusResponse, result), 200
+    def get(self) -> tuple[dict, int]:
+        return dict(self._status_aggregator.status()), 200

--- a/wazo_webhookd/plugins/status/plugin.py
+++ b/wazo_webhookd/plugins/status/plugin.py
@@ -1,22 +1,51 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from xivo.status import Status
+
+from ... import auth
 from .http import StatusResource
 
 if TYPE_CHECKING:
+    from xivo.status import StatusDict
+
+    from ...bus import BusConsumer
     from ...types import PluginDependencyDict
+
+
+def _make_bus_consumer_provider(
+    bus_consumer: BusConsumer,
+):
+    def provide_bus_consumer_status(status: StatusDict) -> None:
+        status['bus_consumer']['status'] = (
+            Status.ok if bus_consumer.consumer_connected() else Status.fail
+        )
+
+    return provide_bus_consumer_status
+
+
+def _provide_master_tenant_status(status: StatusDict) -> None:
+    try:
+        auth.get_master_tenant_uuid()
+    except auth.MasterTenantNotInitializedException:
+        status['master_tenant']['status'] = Status.fail
+    else:
+        status['master_tenant']['status'] = Status.ok
 
 
 class Plugin:
     def load(self, dependencies: PluginDependencyDict) -> None:
         api = dependencies['api']
+        status_aggregator = dependencies['status_aggregator']
         bus_consumer = dependencies['bus_consumer']
-        config = dependencies['config']
+
+        status_aggregator.add_provider(_make_bus_consumer_provider(bus_consumer))
+        status_aggregator.add_provider(_provide_master_tenant_status)
 
         api.add_resource(
-            StatusResource, '/status', resource_class_args=[bus_consumer, config]
+            StatusResource, '/status', resource_class_args=[status_aggregator]
         )

--- a/wazo_webhookd/plugins/status/plugin.py
+++ b/wazo_webhookd/plugins/status/plugin.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from xivo.status import Status
 
-from ... import auth
+from wazo_webhookd import auth
 from .http import StatusResource
 
 if TYPE_CHECKING:

--- a/wazo_webhookd/plugins/status/plugin.py
+++ b/wazo_webhookd/plugins/status/plugin.py
@@ -8,24 +8,13 @@ from typing import TYPE_CHECKING
 from xivo.status import Status
 
 from wazo_webhookd import auth
+
 from .http import StatusResource
 
 if TYPE_CHECKING:
     from xivo.status import StatusDict
 
-    from ...bus import BusConsumer
-    from ...types import PluginDependencyDict
-
-
-def _make_bus_consumer_provider(
-    bus_consumer: BusConsumer,
-):
-    def provide_bus_consumer_status(status: StatusDict) -> None:
-        status['bus_consumer']['status'] = (
-            Status.ok if bus_consumer.consumer_connected() else Status.fail
-        )
-
-    return provide_bus_consumer_status
+    from wazo_webhookd.types import PluginDependencyDict
 
 
 def _provide_master_tenant_status(status: StatusDict) -> None:
@@ -43,7 +32,7 @@ class Plugin:
         status_aggregator = dependencies['status_aggregator']
         bus_consumer = dependencies['bus_consumer']
 
-        status_aggregator.add_provider(_make_bus_consumer_provider(bus_consumer))
+        status_aggregator.add_provider(bus_consumer.provide_status)
         status_aggregator.add_provider(_provide_master_tenant_status)
 
         api.add_resource(

--- a/wazo_webhookd/types.py
+++ b/wazo_webhookd/types.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypedDict
 from flask_restful import Api
 from stevedore.named import NamedExtensionManager
 from wazo_auth_client.client import AuthClient
+from xivo.status import StatusAggregator
 
 from .bus import BusConsumer, BusPublisher
 
@@ -128,6 +129,7 @@ class _BaseDependencyDict(TypedDict):
     bus_consumer: BusConsumer
     bus_publisher: BusPublisher
     config: WebhookdConfigDict
+    status_aggregator: StatusAggregator
 
 
 class ServicePluginDependencyDict(_BaseDependencyDict):


### PR DESCRIPTION
using xivo-lib-python

why: support plugin-extendable status information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/status` response generation and schema to be provider-based, which could affect downstream consumers expecting only the previous fixed keys. Overall scope is contained to status reporting and integration tests.
> 
> **Overview**
> Switches the `/status` endpoint to use `xivo.status.StatusAggregator`, allowing core and plugins to contribute status components instead of building a fixed response in `StatusResource`.
> 
> Adds status providers for `bus_consumer` (via new `BusConsumer.provide_status`) and `master_tenant`, wires a shared `status_aggregator` through controller dependency injection, and updates the OpenAPI schema to allow additional status components.
> 
> Extends integration tests with a new `status_sentinel` test plugin and test case to verify plugin-provided status entries appear in the `/status` response, and enables/install this plugin in the integration test Docker/config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf684e63685f78567b20ca186b83473516ca73ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->