### PR TITLE
Support per-token APNS topics for iOS push notifications

### DIFF
--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -11,7 +11,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, cast
 
 import httpx
 from celery import Task
@@ -51,6 +51,8 @@ class ExternalMobileDict(TypedDict):
     apns_token: str
     apns_voip_token: str
     apns_notification_token: str
+    apns_call_topic: NotRequired[str]
+    apns_default_topic: NotRequired[str]
 
 
 class ExternalConfigDict(TypedDict):
@@ -699,8 +701,17 @@ class PushNotification:
         data: NotificationPayload,
         data_only: bool,
     ):
-        apns_call_topic = self.config['mobile_apns_call_topic']
-        apns_default_topic = self.config['mobile_apns_default_topic']
+        token_call_topic = self.external_tokens.get('apns_call_topic')
+        token_default_topic = self.external_tokens.get('apns_default_topic')
+        apns_call_topic = token_call_topic or self.config['mobile_apns_call_topic']
+        apns_default_topic = token_default_topic or self.config['mobile_apns_default_topic']
+        logger.debug(
+            'APNS topics resolved: call_topic=%s (source=%s), default_topic=%s (source=%s)',
+            apns_call_topic,
+            'token' if token_call_topic else 'config',
+            apns_default_topic,
+            'token' if token_default_topic else 'config',
+        )
 
         if (
             notification_type := data['notification_type']

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -704,7 +704,9 @@ class PushNotification:
         token_call_topic = self.external_tokens.get('apns_call_topic')
         token_default_topic = self.external_tokens.get('apns_default_topic')
         apns_call_topic = token_call_topic or self.config['mobile_apns_call_topic']
-        apns_default_topic = token_default_topic or self.config['mobile_apns_default_topic']
+        apns_default_topic = (
+            token_default_topic or self.config['mobile_apns_default_topic']
+        )
         logger.debug(
             'APNS topics resolved: call_topic=%s (source=%s), default_topic=%s (source=%s)',
             apns_call_topic,

--- a/wazo_webhookd/services/mobile/tests/test_apn.py
+++ b/wazo_webhookd/services/mobile/tests/test_apn.py
@@ -229,9 +229,7 @@ class TestAPNWithPerTokenTopics(TestCase):
             'items': {},
         }
 
-        headers, payload, token = self._push._create_apn_message(
-            None, None, data, True
-        )
+        headers, payload, token = self._push._create_apn_message(None, None, data, True)
 
         assert_that(
             headers,

--- a/wazo_webhookd/services/mobile/tests/test_apn.py
+++ b/wazo_webhookd/services/mobile/tests/test_apn.py
@@ -154,3 +154,116 @@ class TestAPN(TestCase):
             ),
         )
         assert_that(token, equal_to(s.apns_notification_token))
+
+
+class TestAPNWithPerTokenTopics(TestCase):
+    def setUp(self):
+        self.task = Mock()
+        self.config = {
+            'mobile_apns_host': 'api.push.apple.com',
+            'mobile_apns_port': 443,
+            'mobile_apns_call_topic': 'org.wazo-platform.voip',
+            'mobile_apns_default_topic': 'org.wazo-platform',
+        }
+        self.external_tokens = {
+            'apns_voip_token': s.apns_voip_token,
+            'apns_notification_token': s.apns_notification_token,
+            'apns_call_topic': 'com.custom.app.voip',
+            'apns_default_topic': 'com.custom.app',
+        }
+        self.external_config: dict[str, Any] = {}
+        self.jwt = ''
+        self._push = PushNotification(
+            self.task,
+            self.config,  # type: ignore
+            self.external_tokens,  # type: ignore
+            self.external_config,  # type: ignore
+            self.jwt,
+        )
+
+    def test_per_token_call_topic_overrides_config(self):
+        data: NotificationPayload = {
+            'notification_type': NotificationType.INCOMING_CALL,
+            'items': {},
+        }
+
+        headers, payload, token = self._push._create_apn_message(
+            None, None, data, False
+        )
+
+        assert_that(
+            headers,
+            equal_to(
+                {
+                    'apns-topic': 'com.custom.app.voip',
+                    'apns-push-type': 'voip',
+                    'apns-priority': '10',
+                }
+            ),
+        )
+
+    def test_per_token_default_topic_overrides_config_for_cancel(self):
+        data: NotificationPayload = {
+            'notification_type': NotificationType.CANCEL_INCOMING_CALL,
+            'items': {},
+        }
+
+        headers, payload, token = self._push._create_apn_message(
+            None, None, data, False
+        )
+
+        assert_that(
+            headers,
+            equal_to(
+                {
+                    'apns-topic': 'com.custom.app',
+                    'apns-push-type': 'alert',
+                    'apns-priority': '5',
+                }
+            ),
+        )
+
+    def test_per_token_default_topic_overrides_config_for_message(self):
+        data: NotificationPayload = {
+            'notification_type': NotificationType.MESSAGE_RECEIVED,
+            'items': {},
+        }
+
+        headers, payload, token = self._push._create_apn_message(
+            None, None, data, True
+        )
+
+        assert_that(
+            headers,
+            equal_to(
+                {
+                    'apns-topic': 'com.custom.app',
+                    'apns-push-type': 'alert',
+                    'apns-priority': '5',
+                }
+            ),
+        )
+
+    def test_mixed_topics_only_call_topic_from_token(self):
+        self.external_tokens.pop('apns_default_topic')
+        push = PushNotification(
+            self.task,
+            self.config,  # type: ignore
+            self.external_tokens,  # type: ignore
+            self.external_config,  # type: ignore
+            self.jwt,
+        )
+
+        call_data: NotificationPayload = {
+            'notification_type': NotificationType.INCOMING_CALL,
+            'items': {},
+        }
+        headers, _, _ = push._create_apn_message(None, None, call_data, False)
+        assert_that(headers['apns-topic'], equal_to('com.custom.app.voip'))
+
+        cancel_data: NotificationPayload = {
+            'notification_type': NotificationType.CANCEL_INCOMING_CALL,
+            'items': {},
+        }
+        headers, _, _ = push._create_apn_message(None, None, cancel_data, False)
+        assert_that(headers['apns-topic'], equal_to('org.wazo-platform'))


### PR DESCRIPTION
## Summary
Add support for per-token APNS topics in iOS push notifications, allowing individual devices to override the default call and notification topics configured at the application level.

## Key Changes
- Extended `ExternalMobileDict` TypedDict to include optional `apns_call_topic` and `apns_default_topic` fields
- Modified `_create_apn_message()` to check for per-token topics before falling back to config-level topics
- Added debug logging to track which source (token vs config) is used for each topic
- Added comprehensive test suite (`TestAPNWithPerTokenTopics`) covering:
  - Per-token call topic override for incoming calls
  - Per-token default topic override for call cancellations
  - Per-token default topic override for message notifications
  - Mixed scenario where only call topic is provided at token level

## Implementation Details
The topic resolution follows a priority order: token-level topics take precedence over config-level defaults. This allows flexibility for multi-tenant or white-label scenarios where different devices may need to use different bundle identifiers for APNS communication.

https://claude.ai/code/session_013MEa8ciahJcPpnFWXpJsts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes APNS header construction and could cause iOS pushes to fail if incorrect per-token topics are provided; behavior is covered by targeted unit tests but impacts production notification delivery.
> 
> **Overview**
> Adds support for **per-device APNS topics** by allowing external mobile tokens to optionally include `apns_call_topic` and `apns_default_topic`, which now override the global `mobile_apns_*_topic` config when building APNS headers.
> 
> `_create_apn_message()` now resolves topics from token-or-config and emits debug logs indicating the chosen source; tests add coverage for full override and mixed fallback scenarios across call, cancel, and message notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c674204921de1339d981b532ffc16bca5ba738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->