### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
 

--- a/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/plugin.py
+++ b/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/plugin.py
@@ -3,11 +3,34 @@
 
 from __future__ import annotations
 
+import logging
+import threading
+import time
 from typing import Any
+
+from kombu.exceptions import OperationalError
+
+logger = logging.getLogger(__name__)
+
+
+def _dispatch_when_broker_ready() -> None:
+    from .celery_tasks import celery_task_sentinel
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        try:
+            celery_task_sentinel.delay()
+            return
+        except OperationalError as exc:
+            logger.debug('broker not ready, retrying: %r', exc)
+            time.sleep(1)
+    logger.error('gave up dispatching celery_task_sentinel: broker never reachable')
 
 
 class Plugin:
     def load(self, dependencies: dict[str, Any]) -> None:
-        from .celery_tasks import celery_task_sentinel
-
-        celery_task_sentinel.delay()
+        threading.Thread(
+            target=_dispatch_when_broker_ready,
+            name='celery-task-sentinel-dispatch',
+            daemon=True,
+        ).start()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test Docker config and a test plugin startup retry to avoid transient RabbitMQ readiness failures.
> 
> **Overview**
> Pins the integration test `rabbitmq` service image to `rabbitmq:3` for reproducible test environments.
> 
> Updates the `celery_task_sentinel` integration-test plugin to dispatch its task asynchronously and **retry for up to 60s** when the broker isn’t ready (handling `kombu.exceptions.OperationalError`), reducing startup flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6432631a3690406c1b93b48c0abfcafdf6434d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->