### PR TITLE
DO NOT MERGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# DO NOT MERGE
 # wazo-webhookd
 
 [![Build Status](https://jenkins.wazo.community/buildStatus/icon?job=wazo-webhookd)](https://jenkins.wazo.community/job/wazo-webhookd)

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:4.2.6
     ports:
       - "5672"
 

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq:4.2.6
+    image: rabbitmq:3
     ports:
       - "5672"
 

--- a/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/celery_tasks.py
+++ b/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/celery_tasks.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from celery.utils.log import get_task_logger
+
 from wazo_webhookd.celery import app
 
 MARKER_FILE = Path('/tmp/celery_task_sentinel_executed')
 
+logger = get_task_logger(__name__)
+
 
 @app.task
 def celery_task_sentinel() -> None:
-    MARKER_FILE.write_text('ok')
+    try:
+        MARKER_FILE.write_text('ok')
+    except Exception as e:
+        logger.error("Error while writing sentinel file: %r", e, exc_info=True)

--- a/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/plugin.py
+++ b/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/plugin.py
@@ -10,4 +10,12 @@ class Plugin:
     def load(self, dependencies: dict[str, Any]) -> None:
         from .celery_tasks import celery_task_sentinel
 
-        celery_task_sentinel.delay()
+        celery_task_sentinel.apply_async(
+            retry=True,
+            retry_policy={
+                'max_retries': 30,
+                'interval_start': 0,
+                'interval_step': 1.0,
+                'interval_max': 2.0,
+            },
+        )

--- a/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/plugin.py
+++ b/integration_tests/plugins/celery_task_plugin/wazo_webhookd_celery_task_sentinel/plugin.py
@@ -3,19 +3,34 @@
 
 from __future__ import annotations
 
+import logging
+import threading
+import time
 from typing import Any
+
+from kombu.exceptions import OperationalError
+
+logger = logging.getLogger(__name__)
+
+
+def _dispatch_when_broker_ready() -> None:
+    from .celery_tasks import celery_task_sentinel
+
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        try:
+            celery_task_sentinel.delay()
+            return
+        except OperationalError as exc:
+            logger.debug('broker not ready, retrying: %r', exc)
+            time.sleep(1)
+    logger.error('gave up dispatching celery_task_sentinel: broker never reachable')
 
 
 class Plugin:
     def load(self, dependencies: dict[str, Any]) -> None:
-        from .celery_tasks import celery_task_sentinel
-
-        celery_task_sentinel.apply_async(
-            retry=True,
-            retry_policy={
-                'max_retries': 30,
-                'interval_start': 0,
-                'interval_step': 1.0,
-                'interval_max': 2.0,
-            },
-        )
+        threading.Thread(
+            target=_dispatch_when_broker_ready,
+            name='celery-task-sentinel-dispatch',
+            daemon=True,
+        ).start()

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, empty, has_entries, not_
@@ -60,6 +60,25 @@ class ConnectedWaitStrategy(WaitStrategy):
                 has_entries(
                     bus_consumer=has_entries(status='ok'),
                     master_tenant=has_entries(status='ok'),
+                ),
+            )
+
+        until.assert_(webhookd_is_connected, timeout=30, interval=1)
+
+
+class TestComponentConnectedWaitStrategy(WaitStrategy):
+    def wait(self, webhookd):
+        def webhookd_is_connected():
+            try:
+                status = webhookd.status.get()
+            except RequestException:
+                raise AssertionError('wazo-webhookd is not up yet')
+            assert_that(
+                status,
+                has_entries(
+                    bus_consumer=has_entries(status='ok'),
+                    master_tenant=has_entries(status='ok'),
+                    test_component=has_entries(status='ok'),
                 ),
             )
 

--- a/integration_tests/suite/test_celery.py
+++ b/integration_tests/suite/test_celery.py
@@ -7,7 +7,7 @@ from hamcrest import assert_that, equal_to
 from wazo_test_helpers import until
 
 from .helpers.base import BaseIntegrationTest
-from .helpers.wait_strategy import ConnectedWaitStrategy, NoWaitStrategy
+from .helpers.wait_strategy import TestComponentConnectedWaitStrategy, NoWaitStrategy
 
 MARKER_FILE = '/tmp/celery_task_sentinel_executed'
 
@@ -36,7 +36,7 @@ class TestCeleryWorks(BaseIntegrationTest):
 
 class TestCeleryTaskPlugin(BaseIntegrationTest):
     asset = 'base'
-    wait_strategy = ConnectedWaitStrategy()
+    wait_strategy = TestComponentConnectedWaitStrategy()
 
     def tearDown(self) -> None:
         self.docker_exec(['rm', '-f', MARKER_FILE])

--- a/integration_tests/suite/test_celery.py
+++ b/integration_tests/suite/test_celery.py
@@ -7,7 +7,7 @@ from hamcrest import assert_that, equal_to
 from wazo_test_helpers import until
 
 from .helpers.base import BaseIntegrationTest
-from .helpers.wait_strategy import TestComponentConnectedWaitStrategy, NoWaitStrategy
+from .helpers.wait_strategy import NoWaitStrategy, TestComponentConnectedWaitStrategy
 
 MARKER_FILE = '/tmp/celery_task_sentinel_executed'
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to integration test infrastructure and documentation; the main risk is increased test flakiness if the new broker-readiness retry/wait conditions are too strict or too lenient.
> 
> **Overview**
> Adds a **DO NOT MERGE** banner to `README.md`.
> 
> Improves Celery-related integration tests by pinning `rabbitmq` to `rabbitmq:3`, making the `celery_task_sentinel` task log failures to write its marker file, and dispatching the sentinel task in a background thread that retries until the broker is reachable.
> 
> Tightens the Celery plugin test startup gate by introducing `TestComponentConnectedWaitStrategy` (requires `test_component` status to be `ok`) and switching `TestCeleryTaskPlugin` to use it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a0a94b44ce417a20eb61d926e5232dfb7380e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->