### PR TITLE
fix(mobile): cancel incoming call same priority as incoming call

### DIFF
--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -2036,7 +2036,7 @@ class TestMobileCallbackAPNS(TestMobileCallback):
                 detail=has_entry(
                     'full_response',
                     has_entries(
-                        response_body=has_entries(tracker='tracker-notification'),
+                        response_body=has_entries(tracker='tracker-voip'),
                     ),
                 ),
                 event=has_entries(name='call_cancel_push_notification'),
@@ -2044,7 +2044,7 @@ class TestMobileCallbackAPNS(TestMobileCallback):
             ),
         )
 
-        with self.last_apns_request(token='apns-notification-token') as request:
+        with self.last_apns_request(token='apns-voip-token') as request:
             assert_that(
                 request,
                 has_entries(
@@ -2059,7 +2059,7 @@ class TestMobileCallbackAPNS(TestMobileCallback):
         # Test error reason is visible in the logs
         self.apns_third_party.reset()
         self.apns_third_party.mock_simple_response(
-            path='/3/device/apns-notification-token',
+            path='/3/device/apns-voip-token',
             responseBody={'tracker': 'tracker-error'},
             statusCode=400,
         )

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -1908,6 +1908,12 @@ class TestMobileCallbackAPNS(TestMobileCallback):
             }
         )
 
+        # voip-token is used by both INCOMING_CALL and CANCEL_INCOMING_CALL
+        self.apns_third_party.mock_simple_response(
+            path='/3/device/apns-voip-token',
+            responseBody={'tracker': 'tracker-voip'},
+            statusCode=200,
+        )
         self.apns_third_party.mock_simple_response(
             path='/3/device/apns-voip-token',
             responseBody={'tracker': 'tracker-voip'},

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from __future__ import annotations
@@ -592,8 +592,10 @@ class PushNotification:
                 **notify_kwargs,
             )
         elif notification_type == NotificationType.CANCEL_INCOMING_CALL:
+            # need same priority parameters as INCOMING_CALL
             notification = push_service.single_device_data_message(
                 android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
+                low_priority=False,
                 **notify_kwargs,
             )
         else:
@@ -731,10 +733,11 @@ class PushNotification:
                 },
             )
         elif notification_type == NotificationType.CANCEL_INCOMING_CALL:
+            # need same priority as INCOMING_CALL
             headers = {
-                'apns-topic': apns_default_topic,
-                'apns-push-type': 'alert',
-                'apns-priority': '5',
+                'apns-topic': apns_call_topic,
+                'apns-push-type': 'voip',
+                'apns-priority': '10',
             }
             payload = cast(
                 ApnsPayload,

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -774,7 +774,10 @@ class PushNotification:
                     alert['body'] = message_body
                 payload['aps']['alert'] = alert
 
-        if notification_type == NotificationType.INCOMING_CALL:
+        if notification_type in (
+            NotificationType.INCOMING_CALL,
+            NotificationType.CANCEL_INCOMING_CALL,
+        ):
             # TODO(pc-m): The apns_voip_token was added in 20.05
             # the `or self.external_tokens["apns_token"]` should be removed when we stop
             # supporting wazo 20.XX

--- a/wazo_webhookd/services/mobile/tests/test_apn.py
+++ b/wazo_webhookd/services/mobile/tests/test_apn.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from typing import Any
@@ -94,9 +94,9 @@ class TestAPN(TestCase):
             headers,
             equal_to(
                 {
-                    'apns-topic': 'org.wazo-platform',
-                    'apns-push-type': 'alert',
-                    'apns-priority': '5',
+                    'apns-topic': 'org.wazo-platform.voip',
+                    'apns-push-type': 'voip',
+                    'apns-priority': '10',
                 }
             ),
         )
@@ -202,7 +202,7 @@ class TestAPNWithPerTokenTopics(TestCase):
             ),
         )
 
-    def test_per_token_default_topic_overrides_config_for_cancel(self):
+    def test_per_token_call_topic_overrides_config_for_cancel(self):
         data: NotificationPayload = {
             'notification_type': NotificationType.CANCEL_INCOMING_CALL,
             'items': {},
@@ -216,9 +216,9 @@ class TestAPNWithPerTokenTopics(TestCase):
             headers,
             equal_to(
                 {
-                    'apns-topic': 'com.custom.app',
-                    'apns-push-type': 'alert',
-                    'apns-priority': '5',
+                    'apns-topic': 'com.custom.app.voip',
+                    'apns-push-type': 'voip',
+                    'apns-priority': '10',
                 }
             ),
         )
@@ -264,4 +264,4 @@ class TestAPNWithPerTokenTopics(TestCase):
             'items': {},
         }
         headers, _, _ = push._create_apn_message(None, None, cancel_data, False)
-        assert_that(headers['apns-topic'], equal_to('org.wazo-platform'))
+        assert_that(headers['apns-topic'], equal_to('com.custom.app.voip'))

--- a/wazo_webhookd/services/mobile/tests/test_apn.py
+++ b/wazo_webhookd/services/mobile/tests/test_apn.py
@@ -110,7 +110,7 @@ class TestAPN(TestCase):
                 }
             ),
         )
-        assert_that(token, equal_to(s.apns_notification_token))
+        assert_that(token, equal_to(s.apns_voip_token))
 
     def test_wazo_message_received(self):
         data: NotificationPayload = {

--- a/wazo_webhookd/services/mobile/tests/test_fcm.py
+++ b/wazo_webhookd/services/mobile/tests/test_fcm.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from unittest import TestCase
@@ -74,6 +74,7 @@ class TestSendViaFcmLegacy(TestCase):
             data_message=data,
             time_to_live=0,
             android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
+            low_priority=False,
         )
         push_service.notify_single_device.assert_not_called()
 
@@ -246,6 +247,7 @@ class TestSendViaFCMv1(TestCase):
             },
             time_to_live=0,
             android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
+            low_priority=False,
         )
         push_service.notify_single_device.assert_not_called()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes real-time call push behavior on iOS/Android; scope is limited to cancel-incoming-call notification parameters and tests, not auth or data stores.
> 
> **Overview**
> **Cancel incoming call** push notifications are aligned with **incoming call** delivery so devices dismiss ringing reliably.
> 
> On **FCM** (legacy and v1), `cancelIncomingCall` now uses **`low_priority=False`**, matching `incomingCall` instead of default lower priority.
> 
> On **APNS**, cancel uses **`apns-priority` 10** (was 5), drops the default **sound** from the `aps` payload, and keeps **alert** push type on the notification token—avoiding VoIP/CallKit rules reserved for true incoming calls. Unit and integration tests reflect these headers/payloads; an integration comment notes cancel targets the **notification** token, not the VoIP token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d994b34192031d07a1fe693f236460662e249067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->