### PR TITLE
add no-cache to docker build in integration tests

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -9,7 +9,7 @@ egg-info:
 	cd plugins/celery_task_plugin && python setup.py egg_info
 
 webhookd:
-	docker build --pull -t wazoplatform/wazo-webhookd ..
+	docker build --pull --no-cache -t wazoplatform/wazo-webhookd ..
 
 webhookd-test: webhookd egg-info
 	docker build --no-cache -t wazo-webhookd-test -f Dockerfile ..


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to integration test tooling; it only affects Docker build behavior (potentially slower builds) and does not touch runtime code paths.
> 
> **Overview**
> For integration tests, the `webhookd` Makefile target now builds the `wazoplatform/wazo-webhookd` image with `--no-cache`, ensuring a fresh image is produced on each run instead of reusing cached layers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67eff8a2c63205b56218e312a9ea26476842295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->