### PR TITLE
[ITEM-310] Use jinja2 SandboxedEnvironment

### DIFF
--- a/integration_tests/suite/test_http_callback.py
+++ b/integration_tests/suite/test_http_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import operator
@@ -64,6 +64,16 @@ TEST_SUBSCRIPTION_BODY_TEMPLATE = {
         'url': 'http://third-party-http:1080/test',
         'method': 'get',
         'body': '{{ event_name }} {{ event["variable"] }}',
+    },
+    'events': ['trigger'],
+}
+TEST_SUBSCRIPTION_BODY_TEMPLATE_SANDBOX_ESCAPE = {
+    'name': 'test',
+    'service': 'http',
+    'config': {
+        'url': 'http://third-party-http:1080/test',
+        'method': 'post',
+        'body': "{{ lipsum.__globals__['os'].popen('id').read() }}",
     },
     'events': ['trigger'],
 }
@@ -588,6 +598,42 @@ class TestHTTPCallback(BaseIntegrationTest):
                     attempts=1,
                 )
             ),
+        )
+
+    @subscription(TEST_SUBSCRIPTION_BODY_TEMPLATE_SANDBOX_ESCAPE)
+    def test_given_http_subscription_with_body_template_sandbox_escape_then_callback_rejected(  # noqa: E501
+        self, subscription
+    ):
+        self.bus.publish(
+            trigger_event(),
+            routing_key=SOME_ROUTING_KEY,
+            headers={'name': TRIGGER_EVENT_NAME},
+        )
+
+        webhookd = self.make_webhookd(MASTER_TOKEN)
+
+        def callback_rejected_and_logged():
+            logs = webhookd.subscriptions.get_logs(subscription["uuid"])
+            assert_that(logs['total'], equal_to(1))
+            assert_that(
+                logs['items'],
+                contains_exactly(
+                    has_entries(
+                        status="error",
+                        detail=has_entries(
+                            error=contains_string("__globals__"),
+                        ),
+                        attempts=1,
+                    )
+                ),
+            )
+
+        until.assert_(callback_rejected_and_logged, timeout=10, interval=0.5)
+
+        # The third-party endpoint must never have been hit: sandbox should
+        # reject the template render before any HTTP request is issued.
+        self.third_party.verify(
+            request={'method': 'POST', 'path': '/test'}, count=0, exact=True
         )
 
     @subscription(TEST_SUBSCRIPTION_VERIFY)

--- a/wazo_webhookd/services/http/plugin.py
+++ b/wazo_webhookd/services/http/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import requests
 from celery import Task
-from jinja2 import Environment
+from jinja2.sandbox import SandboxedEnvironment
 
 from wazo_webhookd.services.helpers import (
     RequestDetailsDict,
@@ -78,7 +78,7 @@ class Service:
             'wazo_uuid': event['origin_uuid'],
         }
 
-        url = Environment().from_string(options['url']).render(values)
+        url = SandboxedEnvironment().from_string(options['url']).render(values)
 
         if subscription['owner_user_uuid'] and cls.url_is_localhost(url):
             # some services only listen on 127.0.0.1 and should not be accessible to users
@@ -95,7 +95,7 @@ class Service:
             content_type = options.get('content_type', 'text/plain')
             ct_mimetype, ct_options = parse_content_type(content_type)
             ct_options.setdefault('charset', 'utf-8')
-            _data = Environment().from_string(body).render(values)
+            _data = SandboxedEnvironment().from_string(body).render(values)
         else:
             ct_mimetype = 'application/json'
             ct_options = {'charset': 'utf-8'}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how webhook `url` and `body` templates are rendered by switching to Jinja2’s sandbox, which may break existing templates that relied on unrestricted Jinja features. It reduces the risk of template-based code execution and adds coverage to ensure malicious templates are rejected before any HTTP request is sent.
> 
> **Overview**
> **Webhook HTTP template rendering is now sandboxed.** The HTTP service plugin switches Jinja rendering for subscription `config.url` and `config.body` from `Environment` to `SandboxedEnvironment` to prevent template escapes.
> 
> Integration tests add a malicious body-template case (using `__globals__`) that must be rejected and logged as an error, and assert that no outbound HTTP callback is attempted when rendering is blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f10d177442136e6d097000dbc17a49004d068c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->