### PR TITLE
TASK 276 logout notification

### DIFF
--- a/alembic/versions/438c1794cbc6_add_auth_refresh_token_deleted_to_.py
+++ b/alembic/versions/438c1794cbc6_add_auth_refresh_token_deleted_to_.py
@@ -1,0 +1,100 @@
+"""add auth_refresh_token_deleted to mobile subscriptions
+
+Revision ID: 438c1794cbc6
+Revises: 3eb8e3fa4537
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '438c1794cbc6'
+down_revision = '3eb8e3fa4537'
+
+
+NEW_EVENT_NAME = 'auth_refresh_token_deleted'
+
+subscription_table = sa.table(
+    'webhookd_subscription',
+    sa.column('uuid'),
+    sa.column('service'),
+)
+subscription_metadatum_table = sa.table(
+    'webhookd_subscription_metadatum',
+    sa.column('uuid'),
+    sa.column('subscription_uuid'),
+    sa.column('key'),
+    sa.column('value'),
+)
+subscription_event_table = sa.table(
+    'webhookd_subscription_event',
+    sa.column('subscription_uuid'),
+    sa.column('event_name'),
+)
+
+
+def _mobile_subscriptions_select():
+    return (
+        sa.select([subscription_table.c.uuid])
+        .select_from(
+            subscription_table.join(
+                subscription_metadatum_table,
+                subscription_metadatum_table.c.subscription_uuid
+                == subscription_table.c.uuid,
+            )
+        )
+        .where(
+            sa.and_(
+                subscription_table.c.service == 'mobile',
+                subscription_metadatum_table.c.key == 'mobile',
+                subscription_metadatum_table.c.value == 'true',
+            )
+        )
+    )
+
+
+def upgrade():
+    mobile_subscriptions = (
+        sa.select(
+            [
+                subscription_table.c.uuid.label('subscription_uuid'),
+                sa.literal(NEW_EVENT_NAME).label('event_name'),
+            ]
+        )
+        .select_from(
+            subscription_table.join(
+                subscription_metadatum_table,
+                subscription_metadatum_table.c.subscription_uuid
+                == subscription_table.c.uuid,
+            )
+        )
+        .where(
+            sa.and_(
+                subscription_table.c.service == 'mobile',
+                subscription_metadatum_table.c.key == 'mobile',
+                subscription_metadatum_table.c.value == 'true',
+            )
+        )
+    )
+
+    insert_stmt = (
+        insert(subscription_event_table)
+        .from_select(['subscription_uuid', 'event_name'], mobile_subscriptions)
+        .on_conflict_do_nothing(index_elements=['subscription_uuid', 'event_name'])
+    )
+    op.execute(insert_stmt)
+
+
+def downgrade():
+    delete_stmt = subscription_event_table.delete().where(
+        sa.and_(
+            subscription_event_table.c.event_name == NEW_EVENT_NAME,
+            subscription_event_table.c.subscription_uuid.in_(
+                _mobile_subscriptions_select()
+            ),
+        )
+    )
+    op.execute(delete_stmt)

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -243,6 +243,38 @@ class BaseMobileCallbackIntegrationTest(BaseIntegrationTest):
             },
         )
 
+    def _publish_auth_refresh_token_deleted(
+        self,
+        user_uuid: str,
+        client_id: str = 'mobile-client-id',
+        is_mobile: bool = True,
+        tenant_uuid: str = USERS_TENANT,
+        origin_uuid: str = 'my-origin-uuid',
+    ):
+        """
+        Publish an auth_refresh_token_deleted event.
+        Equivalent to the wazo-bus RefreshTokenDeletedEvent.
+        """
+        self.bus.publish(
+            {
+                'name': 'auth_refresh_token_deleted',
+                'origin_uuid': origin_uuid,
+                'data': {
+                    'client_id': client_id,
+                    'mobile': is_mobile,
+                    'user_uuid': user_uuid,
+                    'tenant_uuid': tenant_uuid,
+                },
+            },
+            routing_key=SOME_ROUTING_KEY,
+            headers={
+                'name': 'auth_refresh_token_deleted',
+                'origin_uuid': origin_uuid,
+                'tenant_uuid': tenant_uuid,
+                f'user_uuid:{user_uuid}': True,
+            },
+        )
+
 
 class TestMobileEvents(BaseMobileCallbackIntegrationTest):
     asset = 'proxy'
@@ -277,6 +309,7 @@ class TestMobileEvents(BaseMobileCallbackIntegrationTest):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_1_UUID,
@@ -324,6 +357,7 @@ class TestMobileEvents(BaseMobileCallbackIntegrationTest):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_1_UUID,
@@ -373,6 +407,7 @@ class TestMobileCallbackFCMProxy(BaseMobileCallbackIntegrationTest):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_1_UUID,
@@ -737,6 +772,117 @@ class TestMobileCallbackFCMProxy(BaseMobileCallbackIntegrationTest):
                 ),
             )
 
+    def test_refresh_token_deleted_mobile_sends_logout_push(self):
+        subscription = self._given_mobile_subscription(USER_1_UUID)
+        assert 'auth_refresh_token_deleted' in subscription['events']
+
+        self.fcm_third_party.mock_any_response(
+            {
+                'httpRequest': {
+                    'path': '/fcm/send',
+                    'body': {
+                        'type': 'JSON',
+                        'json': {
+                            'data': {'notification_type': 'appLogout'},
+                        },
+                        'matchType': 'ONLY_MATCHING_FIELDS',
+                    },
+                },
+                'httpResponse': {
+                    'statusCode': 200,
+                    'body': json.dumps({'message_id': 'message-id-app-logout'}),
+                },
+            }
+        )
+
+        self._publish_auth_refresh_token_deleted(
+            USER_1_UUID, client_id='mobile_client', is_mobile=True
+        )
+
+        self._wait_items(
+            functools.partial(
+                self.webhookd.subscriptions.get_logs, subscription['uuid']
+            )
+        )
+
+        logs = self.webhookd.subscriptions.get_logs(subscription['uuid'])
+        assert_that(logs['total'], equal_to(1))
+        assert_that(
+            logs['items'][0],
+            has_entries(
+                status='success',
+                event=has_entries(name='auth_refresh_token_deleted'),
+                attempts=1,
+            ),
+        )
+
+        with self.last_fcm_request() as request:
+            assert_that(
+                request,
+                has_entry(
+                    'data',
+                    has_entries(
+                        notification_type='appLogout',
+                        items=has_entries(
+                            client_id='mobile_client',
+                            reason='session_revoked',
+                            notification_timestamp=an_iso_timestamp(),
+                        ),
+                    ),
+                ),
+            )
+
+    def test_refresh_token_deleted_non_mobile_does_not_send(self):
+        subscription = self._given_mobile_subscription(USER_1_UUID)
+        assert 'auth_refresh_token_deleted' in subscription['events']
+
+        self._publish_auth_refresh_token_deleted(
+            USER_1_UUID, client_id='cli-client', is_mobile=False
+        )
+
+        self._wait_items(
+            functools.partial(
+                self.webhookd.subscriptions.get_logs, subscription['uuid']
+            )
+        )
+
+        logs = self.webhookd.subscriptions.get_logs(subscription['uuid'])
+        assert_that(
+            logs['items'][0],
+            has_entries(
+                status='success',
+                event=has_entries(name='auth_refresh_token_deleted'),
+                detail=equal_to({}),
+            ),
+        )
+
+        self.fcm_third_party.assert_verify(
+            request={'path': '/fcm/send'}, count=0, exact=True
+        )
+
+    def test_refresh_token_deleted_after_external_auth_deleted_does_not_send(self):
+        subscription = self._given_mobile_subscription(USER_1_UUID)
+
+        self._publish_auth_user_external_auth_deleted(USER_1_UUID)
+
+        def assert_subscription_gone():
+            current = self.webhookd.subscriptions.list(recurse=True)
+            assert all(
+                item['uuid'] != subscription['uuid'] for item in current['items']
+            )
+
+        until.assert_(assert_subscription_gone, timeout=10, interval=0.5)
+
+        self._publish_auth_refresh_token_deleted(
+            USER_1_UUID, client_id='mobile_client', is_mobile=True
+        )
+
+        time.sleep(1.0)
+
+        self.fcm_third_party.assert_verify(
+            request={'path': '/fcm/send'}, count=0, exact=True
+        )
+
 
 class TestMobileCallback(BaseMobileCallbackIntegrationTest):
     asset = 'base'
@@ -826,6 +972,7 @@ class TestMobileCallbackFCMLegacy(TestMobileCallback):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_1_UUID,
@@ -1175,6 +1322,67 @@ class TestMobileCallbackFCMLegacy(TestMobileCallback):
             ),
         )
 
+    def test_app_logout_notification(self):
+        subscription = self._given_mobile_subscription(USER_1_UUID)
+
+        self.fcm_third_party.mock_any_response(
+            {
+                'httpRequest': {
+                    'path': '/fcm/send',
+                    'body': {
+                        'type': 'JSON',
+                        'json': {'data': {'notification_type': 'appLogout'}},
+                        'matchType': 'ONLY_MATCHING_FIELDS',
+                    },
+                },
+                'httpResponse': {
+                    'statusCode': 200,
+                    'body': json.dumps({'message_id': 'message-id-app-logout'}),
+                },
+            }
+        )
+
+        self._publish_auth_refresh_token_deleted(
+            USER_1_UUID, client_id='mobile_client', is_mobile=True
+        )
+
+        self._wait_items(
+            functools.partial(
+                self.webhookd.subscriptions.get_logs, subscription['uuid']
+            )
+        )
+
+        logs = self.webhookd.subscriptions.get_logs(subscription['uuid'])
+        assert_that(logs['total'], equal_to(1))
+        assert_that(
+            logs['items'][0],
+            has_entries(
+                status='success',
+                event=has_entries(name='auth_refresh_token_deleted'),
+                detail=has_entry(
+                    'full_response',
+                    has_entry('topic_message_id', 'message-id-app-logout'),
+                ),
+                attempts=1,
+            ),
+        )
+
+        with self.last_fcm_request() as request:
+            assert_that(
+                request,
+                has_entry(
+                    'data',
+                    has_entries(
+                        notification_type='appLogout',
+                        items=has_entries(
+                            client_id='mobile_client',
+                            reason='session_revoked',
+                            notification_timestamp=an_iso_timestamp(),
+                        ),
+                    ),
+                ),
+            )
+
 
 class TestMobileCallbackFCMv1(TestMobileCallback):
     def setUp(self):
@@ -1324,6 +1532,7 @@ class TestMobileCallbackFCMv1(TestMobileCallback):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_1_UUID,
@@ -1711,6 +1920,75 @@ class TestMobileCallbackFCMv1(TestMobileCallback):
             ),
         )
 
+    def test_app_logout_notification(self):
+        subscription = self._given_mobile_subscription(USER_1_UUID)
+
+        self.fcm_third_party.mock_any_response(
+            {
+                'httpRequest': {
+                    'path': '/v1/projects/project-123/messages:send',
+                    'headers': {
+                        'Authorization': [
+                            f'Bearer {self.oauth2_token["access_token"]}'
+                        ],
+                    },
+                },
+                'httpResponse': {
+                    'statusCode': 200,
+                    'body': json.dumps({'name': 'message-id-app-logout'}),
+                },
+            }
+        )
+
+        self._publish_auth_refresh_token_deleted(
+            USER_1_UUID, client_id='mobile_client', is_mobile=True
+        )
+
+        self._wait_items(
+            functools.partial(
+                self.webhookd.subscriptions.get_logs, subscription['uuid']
+            )
+        )
+
+        logs = self.webhookd.subscriptions.get_logs(subscription['uuid'])
+        assert_that(logs['total'], equal_to(1))
+        assert_that(
+            logs['items'][0],
+            has_entries(
+                status='success',
+                event=has_entries(name='auth_refresh_token_deleted'),
+                detail=has_entry(
+                    'full_response',
+                    has_entry('topic_message_id', 'message-id-app-logout'),
+                ),
+                attempts=1,
+            ),
+        )
+
+        with self.last_fcm_request() as request:
+            assert_that(
+                request,
+                has_entry(
+                    'message',
+                    has_entry(
+                        'data',
+                        has_entries(
+                            notification_type='appLogout',
+                            items=instance_of(str),
+                        ),
+                    ),
+                ),
+            )
+            items_data = json.loads(request['message']['data']['items'])
+            assert_that(
+                items_data,
+                has_entries(
+                    client_id='mobile_client',
+                    reason='session_revoked',
+                    notification_timestamp=an_iso_timestamp(),
+                ),
+            )
+
 
 class TestMobileCallbackAPNS(TestMobileCallback):
     def setUp(self):
@@ -1790,6 +2068,7 @@ class TestMobileCallbackAPNS(TestMobileCallback):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_2_UUID,
@@ -1936,6 +2215,7 @@ class TestMobileCallbackAPNS(TestMobileCallback):
                     'user_voicemail_message_created',
                     'global_voicemail_message_created',
                     'user_missed_call',
+                    'auth_refresh_token_deleted',
                 ),
                 owner_tenant_uuid=USERS_TENANT,
                 owner_user_uuid=USER_2_UUID,
@@ -2527,3 +2807,89 @@ class TestMobileCallbackAPNS(TestMobileCallback):
             )
 
         self.webhookd.subscriptions.delete(subscription["uuid"])
+
+    def test_app_logout_notification(self):
+        self.auth.set_external_auth(
+            {
+                'token': 'token-android',
+                'apns_token': 'token-ios',
+                'apns_notification_token': 'apns-notification-token',
+            }
+        )
+        subscription = self._given_mobile_subscription(USER_1_UUID)
+
+        self.apns_third_party.mock_simple_response(
+            path='/3/device/apns-notification-token',
+            responseBody={'tracker': 'tracker-app-logout'},
+            statusCode=200,
+        )
+
+        self._publish_auth_refresh_token_deleted(
+            USER_1_UUID, client_id='mobile_client', is_mobile=True
+        )
+
+        def assert_apns_notification_posted():
+            self.apns_third_party.assert_verify(
+                request={
+                    'path': '/3/device/apns-notification-token',
+                    'headers': [
+                        {
+                            'name': 'authorization',
+                            'values': [f'Bearer {JWT_TENANT_0}'],
+                        },
+                        {'name': 'user-agent', 'values': ['wazo-webhookd']},
+                    ],
+                },
+            )
+
+        until.assert_(assert_apns_notification_posted, timeout=10, interval=0.5)
+
+        self._wait_items(
+            functools.partial(
+                self.webhookd.subscriptions.get_logs, subscription['uuid']
+            )
+        )
+
+        logs = self.webhookd.subscriptions.get_logs(subscription['uuid'])
+        assert_that(logs['total'], equal_to(1))
+        assert_that(
+            logs['items'][0],
+            has_entries(
+                status='success',
+                event=has_entries(name='auth_refresh_token_deleted'),
+                detail=has_entry(
+                    'full_response',
+                    has_entry(
+                        'response_body',
+                        has_entry('tracker', 'tracker-app-logout'),
+                    ),
+                ),
+                attempts=1,
+            ),
+        )
+
+        with self.last_apns_request(token='apns-notification-token') as request:
+            assert 'aps' in request and 'alert' in request['aps']
+            assert_that(
+                request['aps']['alert'],
+                has_entries(
+                    title='Signed out',
+                    body=contains_string('signed out'),
+                ),
+            )
+            assert_that(
+                request,
+                has_entry(
+                    'data',
+                    has_entries(
+                        notification_type='appLogout',
+                        items=has_entries(
+                            client_id='mobile_client',
+                            reason='session_revoked',
+                            notification_timestamp=an_iso_timestamp(),
+                        ),
+                    ),
+                ),
+            )
+
+        self.webhookd.subscriptions.delete(subscription['uuid'])

--- a/wazo_webhookd/plugins/mobile/api.yml
+++ b/wazo_webhookd/plugins/mobile/api.yml
@@ -46,7 +46,7 @@ definitions:
     properties:
       notification_type:
         type: string
-        pattern: '(?!^(messageReceived|voicemailReceived|incomingCall|cancelIncomingCall)$)(^[a-z0-9_]+$)'
+        pattern: '(?!^(messageReceived|voicemailReceived|incomingCall|cancelIncomingCall|missedCall|appLogout)$)(^[a-z0-9_]+$)'
         description: A name without special characters to differenciate the notification from others
         example: myCustomNotification
         minLength: 1

--- a/wazo_webhookd/plugins/mobile/tests/test_schema.py
+++ b/wazo_webhookd/plugins/mobile/tests/test_schema.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -44,3 +44,22 @@ def test_schema_valid() -> None:
     }
     validated = notification_schema.loads(json.dumps(input_data))
     assert validated == input_data
+
+
+def test_schema_app_logout_is_reserved() -> None:
+    data = {
+        'notification_type': NotificationType.APP_LOGOUT,
+        'user_uuid': str(uuid.uuid4()),
+        'title': 'Signed out',
+        'body': 'You have been signed out.',
+        'extra': {},
+    }
+    with pytest.raises(ValidationError) as exec_info:
+        notification_schema.loads(json.dumps(data))
+
+    error: ValidationError = exec_info.value
+    assert error.messages == {
+        'notification_type': [
+            f'The type "{NotificationType.APP_LOGOUT}" is a reserved type.'
+        ],
+    }

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from __future__ import annotations
@@ -137,6 +137,7 @@ class NotificationType(StrEnum):
     CANCEL_INCOMING_CALL = 'cancelIncomingCall'
     PLUGIN = 'plugin'
     MISSED_CALL = 'missedCall'
+    APP_LOGOUT = 'appLogout'
 
 
 RESERVED_NOTIFICATION_TYPES = (
@@ -145,7 +146,18 @@ RESERVED_NOTIFICATION_TYPES = (
     NotificationType.INCOMING_CALL,
     NotificationType.CANCEL_INCOMING_CALL,
     NotificationType.MISSED_CALL,
+    NotificationType.APP_LOGOUT,
 )
+
+MOBILE_SUBSCRIPTION_EVENTS = [
+    'chatd_user_room_message_created',
+    'call_push_notification',
+    'call_cancel_push_notification',
+    'user_voicemail_message_created',
+    'global_voicemail_message_created',
+    'user_missed_call',
+    'auth_refresh_token_deleted',
+]
 
 MAP_NAME_TO_NOTIFICATION_TYPE = {
     'user_voicemail_message_created': NotificationType.VOICEMAIL_RECEIVED,
@@ -154,6 +166,7 @@ MAP_NAME_TO_NOTIFICATION_TYPE = {
     'call_cancel_push_notification': NotificationType.CANCEL_INCOMING_CALL,
     'chatd_user_room_message_created': NotificationType.MESSAGE_RECEIVED,
     'user_missed_call': NotificationType.MISSED_CALL,
+    'auth_refresh_token_deleted': NotificationType.APP_LOGOUT,
 }
 
 
@@ -273,14 +286,7 @@ class Service:
                         f'{tenant_uuid}/{user_uuid}'
                     ),
                     'service': 'mobile',
-                    'events': [
-                        'chatd_user_room_message_created',
-                        'call_push_notification',
-                        'call_cancel_push_notification',
-                        'user_voicemail_message_created',
-                        'global_voicemail_message_created',
-                        'user_missed_call',
-                    ],
+                    'events': list(MOBILE_SUBSCRIPTION_EVENTS),
                     'events_user_uuid': user_uuid,
                     # 'events_tenant_uuid': tenant_uuid,
                     'owner_user_uuid': user_uuid,
@@ -339,6 +345,12 @@ class Service:
             event['data'].get('user_uuid') == user_uuid
             # and event['data']['tenant_uuid'] == tenant_uuid
             and event['name'] == 'chatd_user_room_message_created'
+        ):
+            return None
+
+        if (
+            event['name'] == 'auth_refresh_token_deleted'
+            and event['data'].get('mobile') is not True
         ):
             return None
 
@@ -441,6 +453,22 @@ class PushNotification:
             message_body=f'From: {display_name} ({display_number})',
             extra={'items': payload},
             data_only=True,
+        )
+
+    def appLogout(self, data: dict[str, Any]) -> NotificationSentStatusDict:
+        payload = {
+            'notification_timestamp': generate_timestamp(),
+            'client_id': data.get('client_id'),
+            'reason': 'session_revoked',
+        }
+        return self.send_notification(
+            NotificationType.APP_LOGOUT,
+            message_title='Signed out',
+            message_body=(
+                "You have been signed out. "
+                "Calls and notifications won't arrive on this application."
+            ),
+            extra={'items': payload},
         )
 
     def send_notification(

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -241,7 +241,6 @@ class Service:
 
     def _ensure_mobile_subscription(self, user_uuid: str, tenant_uuid: str) -> None:
         """Create or update mobile subscription for a user, ensuring only one exists."""
-        # Delete any existing mobile subscriptions for this user
         subscriptions = self.subscription_service.list(
             owner_user_uuid=user_uuid,
             owner_tenant_uuids=[tenant_uuid],

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -465,9 +465,10 @@ class PushNotification:
             message_title='Signed out',
             message_body=(
                 "You have been signed out. "
-                "Calls and notifications won't arrive on this application."
+                "Calls and notifications won't be received by this application."
             ),
             extra={'items': payload},
+            data_only=True,
         )
 
     def send_notification(

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -777,7 +777,8 @@ class PushNotification:
                 'apns-push-type': 'alert',
                 'apns-priority': '5',
             }
-            # For non-call notifications (messageReceived, voicemailReceived, missedCall),
+            # For non-call notifications
+            # (messageReceived, voicemailReceived, missedCall, appLogout),
             # wrap custom fields under top-level "data" so that iOS receives them in
             # notification.data and the mobile app can read items.data_only.
             payload = cast(

--- a/wazo_webhookd/services/mobile/tests/test_apn.py
+++ b/wazo_webhookd/services/mobile/tests/test_apn.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from typing import Any
@@ -107,6 +107,46 @@ class TestAPN(TestCase):
                     'aps': {"badge": 1, "sound": "default", "content-available": 1},
                     'notification_type': NotificationType.CANCEL_INCOMING_CALL,
                     'items': {},
+                }
+            ),
+        )
+        assert_that(token, equal_to(s.apns_notification_token))
+
+    def test_wazo_app_logout(self):
+        message_title = 'Signed out'
+        message_body = "You have been signed out."
+        data: NotificationPayload = {
+            'notification_type': NotificationType.APP_LOGOUT,
+            'items': {'reason': 'session_revoked'},
+        }
+
+        headers, payload, token = self._push._create_apn_message(
+            message_title,
+            message_body,
+            data,
+            False,
+        )
+
+        assert_that(
+            headers,
+            equal_to(
+                {
+                    'apns-topic': 'org.wazo-platform',
+                    'apns-push-type': 'alert',
+                    'apns-priority': '5',
+                }
+            ),
+        )
+        assert_that(
+            payload,
+            equal_to(
+                {
+                    'aps': {
+                        'badge': 1,
+                        'sound': 'default',
+                        'alert': {'title': message_title, 'body': message_body},
+                    },
+                    'data': data,
                 }
             ),
         )

--- a/wazo_webhookd/services/mobile/tests/test_fcm.py
+++ b/wazo_webhookd/services/mobile/tests/test_fcm.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from unittest import TestCase
@@ -125,6 +125,32 @@ class TestSendViaFcmLegacy(TestCase):
             data_message=data,
             time_to_live=0,
             low_priority=False,
+            android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
+        )
+
+    @patch('wazo_webhookd.services.mobile.plugin.FCMNotificationLegacy')
+    def test_send_app_logout(self, FCMNotificationLegacy):
+        push_service = FCMNotificationLegacy.return_value
+
+        title = 'Signed out'
+        body = "You have been signed out."
+        data: NotificationPayload = {
+            'notification_type': NotificationType.APP_LOGOUT,
+            'items': {},
+        }
+
+        self.push_notification._send_via_fcm(title, body, data, data_only=False)
+
+        assert push_service.FCM_END_POINT == FCMNotificationLegacy.FCM_END_POINT
+        FCMNotificationLegacy.assert_called_once_with(api_key=s.fcm_api_key)
+        push_service.single_device_data_message.assert_not_called()
+        push_service.notify_single_device.assert_called_once_with(
+            registration_id=s.token,
+            data_message=data,
+            time_to_live=0,
+            message_title=title,
+            message_body=body,
+            badge=1,
             android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
         )
 
@@ -313,4 +339,38 @@ class TestSendViaFCMv1(TestCase):
             time_to_live=0,
             android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
             low_priority=False,
+        )
+
+    @patch('wazo_webhookd.services.mobile.plugin.json.loads')
+    @patch('wazo_webhookd.services.mobile.plugin.FCMNotification')
+    def test_send_app_logout(self, FCMNotification, json_loads):
+        push_service = FCMNotification.return_value
+
+        title = 'Signed out'
+        body = "You have been signed out."
+        data: NotificationPayload = {
+            'notification_type': NotificationType.APP_LOGOUT,
+            'items': {},
+        }
+
+        self.push_notification._send_via_fcm(title, body, data, data_only=False)
+
+        assert push_service.FCM_END_POINT == FCMNotification.FCM_END_POINT
+
+        json_loads.assert_called_once_with(s.fcm_service_account_info)
+        FCMNotification.assert_called_once_with(
+            service_account_info=json_loads.return_value
+        )
+        push_service.single_device_data_message.assert_not_called()
+        push_service.notify_single_device.assert_called_once_with(
+            registration_token=s.token,
+            data_message={
+                'notification_type': NotificationType.APP_LOGOUT,
+                'items': '',
+            },
+            time_to_live=0,
+            message_title=title,
+            message_body=body,
+            badge=1,
+            android_channel_id=DEFAULT_ANDROID_CHANNEL_ID,
         )


### PR DESCRIPTION
- **feat(mobile): add appLogout push notification**
- **fcm_client: log legacy requests**
- **feat(mobile/app_logout): mobile subscriptions migration**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-revocation signaling to mobile devices via push; behavior is gated on `mobile: true` and covered by broad integration tests, but incorrect filtering could notify wrong clients or miss logouts.
> 
> **Overview**
> Mobile clients are notified to sign out when a **mobile** refresh token is revoked, by handling the `auth_refresh_token_deleted` bus event and sending a reserved **`appLogout`** push (FCM/APNS) with `reason: session_revoked` and `client_id`.
> 
> New and existing mobile webhook subscriptions gain the `auth_refresh_token_deleted` event via `MOBILE_SUBSCRIPTION_EVENTS` and an Alembic migration; pushes are skipped when `mobile` is not true. **`appLogout`** is blocked from the public mobile notification API like other system types.
> 
> Integration and unit tests cover FCM (legacy, v1, proxy), APNS, non-mobile tokens, and no push after mobile external auth is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d5860ff7d6dd4e49e80dd56c06a485506bda2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->