### PR TITLE
ITEM 359 optimize push handling auth

### DIFF
--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -2574,13 +2574,17 @@ class TestMobileSubscriptionAuthCaching(BaseMobileCallbackIntegrationTest):
             },
         )
 
+    def tearDown(self) -> None:
+        self.webhookd = self.make_webhookd(MASTER_TOKEN)
+        super().tearDown()
+
     def test_consecutive_subscription_events_share_auth_token(self) -> None:
         # Pin to one Celery worker so both tasks land in the same process and
         # share the class-level cache; otherwise autoscale may spawn a new
         # child per task.
         with self.webhookd_with_config({'celery': {'worker_min': 1, 'worker_max': 1}}):
-            webhookd = self.make_webhookd(MASTER_TOKEN)
-            self.wait_strategy.wait(webhookd)
+            self.webhookd = self.make_webhookd(MASTER_TOKEN)
+            self.wait_strategy.wait(self.webhookd)
 
             subscription = self._given_mobile_subscription(USER_1_UUID)
 
@@ -2600,7 +2604,7 @@ class TestMobileSubscriptionAuthCaching(BaseMobileCallbackIntegrationTest):
 
                 self._wait_items(
                     functools.partial(
-                        webhookd.subscriptions.get_logs, subscription["uuid"]
+                        self.webhookd.subscriptions.get_logs, subscription["uuid"]
                     ),
                     number=2,
                 )

--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -2527,3 +2527,95 @@ class TestMobileCallbackAPNS(TestMobileCallback):
             )
 
         self.webhookd.subscriptions.delete(subscription["uuid"])
+
+
+class TestMobileSubscriptionAuthCaching(BaseMobileCallbackIntegrationTest):
+    """Verify the wazo-auth service-token cache survives across subscription tasks.
+
+    Production push notifications flow through subscriptions:
+        bus event -> hook_runner_task -> Service.run -> get_external_data -> get_auth
+
+    A correctly-cached token means two sequential bus events produce exactly ONE
+    POST /0.1/token to wazo-auth, not two.
+    """
+
+    asset = 'proxy'
+    wait_strategy = ConnectedWaitStrategy()
+
+    def setUp(self):
+        super().setUp()
+        self.fcm_third_party = MockServerClient(
+            f'http://127.0.0.1:{self.service_port(443, "fcm.proxy.example.com")}'
+        )
+        self.fcm_third_party.reset()
+        self.auth.set_external_auth({'token': 'token-android', 'apns_token': None})
+
+    def _publish_missed_call(self, user_uuid):
+        self.bus.publish(
+            {
+                'name': 'user_missed_call',
+                'origin_uuid': 'my-origin-uuid',
+                'data': {
+                    'user_uuid': str(user_uuid),
+                    'caller_user_uuid': 'ad5b78cf-6e15-45c7-9ef3-bec36e07e8d6',
+                    'caller_id_name': 'John Doe',
+                    'caller_id_number': '12221114455',
+                    'dialed_extension': '8000',
+                    'conversation_id': '1718908219.36',
+                    'reason': 'no-answer',
+                },
+            },
+            routing_key=SOME_ROUTING_KEY,
+            headers={
+                'name': 'user_missed_call',
+                'origin_uuid': 'my-origin-uuid',
+                'tenant_uuid': USERS_TENANT,
+                f'user_uuid:{user_uuid}': True,
+            },
+        )
+
+    def test_consecutive_subscription_events_share_auth_token(self) -> None:
+        # Pin to one Celery worker so both tasks land in the same process and
+        # share the class-level cache; otherwise autoscale may spawn a new
+        # child per task.
+        with self.webhookd_with_config({'celery': {'worker_min': 1, 'worker_max': 1}}):
+            webhookd = self.make_webhookd(MASTER_TOKEN)
+            self.wait_strategy.wait(webhookd)
+
+            subscription = self._given_mobile_subscription(USER_1_UUID)
+
+            self.fcm_third_party.mock_any_response(
+                {
+                    'httpRequest': {'method': 'POST', 'path': '/fcm/send'},
+                    'httpResponse': {
+                        'statusCode': 200,
+                        'body': json.dumps({'message_id': 'ok'}),
+                    },
+                }
+            )
+
+            with self.auth.capture_requests() as capture:
+                self._publish_missed_call(USER_1_UUID)
+                self._publish_missed_call(USER_1_UUID)
+
+                self._wait_items(
+                    functools.partial(
+                        webhookd.subscriptions.get_logs, subscription["uuid"]
+                    ),
+                    number=2,
+                )
+
+            token_calls = [
+                r
+                for r in capture.requests
+                if r['path'] == '/0.1/token' and r['method'] == 'POST'
+            ]
+            assert len(token_calls) == 1, (
+                f'Expected 1 POST /0.1/token but got {len(token_calls)}. '
+                'Auth token cache is not shared across Celery tasks on the '
+                'subscription path (hook_runner_task -> Service.run).'
+            )
+
+
+# TODO: cover cache-401 recovery end-to-end once wazo-auth-mock supports a
+# one-shot response override (currently unit-tested only).

--- a/integration_tests/suite/test_mobile_notifications.py
+++ b/integration_tests/suite/test_mobile_notifications.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -227,6 +227,97 @@ class TestNotifications(BaseIntegrationTest):
             },
         )
         until.return_(verify_called, timeout=15, interval=0.5)
+
+
+class TestMobileNotificationAuthCaching(BaseIntegrationTest):
+    """Verify that sequential push notifications share the same auth token.
+
+    Each notification must not trigger a new POST /0.1/token call: the Celery
+    worker should reuse the cached service token for subsequent tasks within
+    the same worker process.
+    """
+
+    asset = 'proxy'
+    wait_strategy = ConnectedWaitStrategy()
+
+    def setUp(self):
+        super().setUp()
+        self.auth = self.make_auth()
+        requests.post(
+            self.auth.url('0.1/users'),
+            json={
+                'email_address': 'foo@bar',
+                'username': 'foobar',
+                'password': 'secret',
+                'uuid': USER_1_UUID,
+            },
+            headers={'Wazo-Tenant': USERS_TENANT},
+        )
+
+    def test_sequential_notifications_reuse_auth_token(self) -> None:
+        notification = {
+            'notification_type': 'plugin',
+            'user_uuid': USER_1_UUID,
+            'title': 'test',
+            'body': 'test',
+            'extra': {
+                'plugin': {
+                    'id': 'test',
+                    'entityId': 'test-plugin',
+                    'action': 'test',
+                    'payload': {},
+                },
+            },
+        }
+
+        # Use a single Celery worker so both tasks go to the same process,
+        # guaranteeing the class-level cache is shared between invocations.
+        with self.webhookd_with_config({'celery': {'worker_min': 1, 'worker_max': 1}}):
+            webhookd = self.make_webhookd(MASTER_TOKEN, USERS_TENANT)
+            self.wait_strategy.wait(webhookd)
+
+            third_party = MockServerClient(
+                f'http://127.0.0.1:{self.service_port(443, "fcm.proxy.example.com")}'
+            )
+            third_party.reset()
+            third_party.mock_any_response(
+                {
+                    'httpRequest': {'method': 'POST', 'path': '/fcm/send'},
+                    'httpResponse': {
+                        'statusCode': 200,
+                        'body': json.dumps({'message_id': 'ok'}),
+                    },
+                }
+            )
+
+            self.auth.reset_external_auth()
+            # Intentionally no set_external_config: GET /external/mobile/config
+            # returns 404 and the code falls back to the Nestbox JWT path.
+            self.auth.set_external_auth({'token': 'token-android', 'apns_token': None})
+
+            with self.auth.capture_requests() as capture:
+                webhookd.mobile_notifications.send(notification)
+                webhookd.mobile_notifications.send(notification)
+
+                until.return_(
+                    partial(
+                        third_party.verify,
+                        request={'method': 'POST', 'path': '/fcm/send'},
+                        count=2,
+                    ),
+                    timeout=30,
+                    interval=0.5,
+                )
+
+            token_calls = [
+                r
+                for r in capture.requests
+                if r['path'] == '/0.1/token' and r['method'] == 'POST'
+            ]
+            assert len(token_calls) == 1, (
+                f'Expected 1 POST /0.1/token but got {len(token_calls)}. '
+                'The service auth token is not being cached between Celery tasks.'
+            )
 
 
 class TestNotificationsFCMv1(BaseIntegrationTest):

--- a/wazo_webhookd/celery.py
+++ b/wazo_webhookd/celery.py
@@ -30,11 +30,12 @@ def configure(config: WebhookdConfigDict) -> None:
     app.conf.worker_hijack_root_logger = False
     app.conf.worker_loglevel = logging.getLevelName(config['log_level']).upper()
 
-    # avoid memory leaks
-    app.conf.worker_max_tasks_per_child = 1_000
-    # max mem need to be large enough for baseline
-    # else no task reuse
-    app.conf.worker_max_memory_per_child = 1_000_000  # 1GB
+    # recycle workers to bound memory growth; thresholds are operator-tunable
+    # via config so small deployments can lower them.
+    app.conf.worker_max_tasks_per_child = config['celery']['worker_max_tasks_per_child']
+    app.conf.worker_max_memory_per_child = config['celery'][
+        'worker_max_memory_per_child'
+    ]
 
 
 def start_celery(argv: tuple[str, ...]) -> int | None:

--- a/wazo_webhookd/celery.py
+++ b/wazo_webhookd/celery.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -30,8 +30,11 @@ def configure(config: WebhookdConfigDict) -> None:
     app.conf.worker_hijack_root_logger = False
     app.conf.worker_loglevel = logging.getLevelName(config['log_level']).upper()
 
+    # avoid memory leaks
     app.conf.worker_max_tasks_per_child = 1_000
-    app.conf.worker_max_memory_per_child = 100_000
+    # max mem need to be large enough for baseline
+    # else no task reuse
+    app.conf.worker_max_memory_per_child = 1_000_000  # 1GB
 
 
 def start_celery(argv: tuple[str, ...]) -> int | None:

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -48,7 +48,8 @@ _DEFAULT_CONFIG = {
         'worker_min': 3,
         'worker_max': 5,
         'worker_max_tasks_per_child': 1_000,
-        'worker_max_memory_per_child': 1_000_000,  # KiB (~1 GiB)
+        # KiB; raise per deployment if baseline memory per worker exceeds ~100 MiB
+        'worker_max_memory_per_child': 150_000,
     },
     'db_uri': (
         'postgresql://asterisk:proformatique@localhost/asterisk?'

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -47,6 +47,8 @@ _DEFAULT_CONFIG = {
         'worker_pid_file': os.path.join(_PID_DIR, 'celery-worker.pid'),
         'worker_min': 3,
         'worker_max': 5,
+        'worker_max_tasks_per_child': 1_000,
+        'worker_max_memory_per_child': 1_000_000,  # KB
     },
     'db_uri': (
         'postgresql://asterisk:proformatique@localhost/asterisk?'

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -48,7 +48,7 @@ _DEFAULT_CONFIG = {
         'worker_min': 3,
         'worker_max': 5,
         'worker_max_tasks_per_child': 1_000,
-        'worker_max_memory_per_child': 1_000_000,  # KB
+        'worker_max_memory_per_child': 1_000_000,  # KiB (~1 GiB)
     },
     'db_uri': (
         'postgresql://asterisk:proformatique@localhost/asterisk?'

--- a/wazo_webhookd/plugins/mobile/celery_tasks.py
+++ b/wazo_webhookd/plugins/mobile/celery_tasks.py
@@ -48,10 +48,9 @@ def send_notification(
                 str(e),
             )
             return False
-        if PushNotificationService.is_cached_auth_401(e):
-            # cache invalidation should occur in get_external_data;
-            # retry once so the next attempt mints a fresh token
-            raise task.retry(exc=e, countdown=1, max_retries=1)
+        # No task-level retry on the API path: fail fast and let the client
+        # decide whether to retry. get_external_data already absorbs the
+        # cached-auth 401 race in-band via its own inline retry.
         raise
 
     push_notification = PushNotification(

--- a/wazo_webhookd/plugins/mobile/celery_tasks.py
+++ b/wazo_webhookd/plugins/mobile/celery_tasks.py
@@ -42,12 +42,16 @@ def send_notification(
             jwt,
         ) = PushNotificationService.get_external_data(config, notification['user_uuid'])
     except requests.HTTPError as e:
-        if e.response and e.response.status_code == 404:
+        if e.response is not None and e.response.status_code == 404:
             logger.error(
                 'Cannot send notification as no authentication exists for mobile (%s)',
                 str(e),
             )
             return False
+        if PushNotificationService.is_cached_auth_401(e):
+            # cache invalidation should occur in get_external_data;
+            # retry once so the next attempt mints a fresh token
+            raise task.retry(exc=e, countdown=1, max_retries=1)
         raise
 
     push_notification = PushNotification(

--- a/wazo_webhookd/plugins/mobile/tests/test_celery_tasks.py
+++ b/wazo_webhookd/plugins/mobile/tests/test_celery_tasks.py
@@ -1,11 +1,22 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from unittest.mock import Mock, patch, sentinel
 
+import pytest
+import requests
+from celery.exceptions import Retry
+
 from ..celery_tasks import send_notification
+
+
+def _make_http_error(status_code, url='https://localhost:9497/0.1/users/x'):
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = url
+    return requests.HTTPError(response=response)
 
 
 @patch('wazo_webhookd.plugins.mobile.celery_tasks.PushNotificationService')
@@ -38,3 +49,58 @@ def test_send_notification(
         sentinel.body,
         sentinel.extra,
     )
+
+
+@patch('wazo_webhookd.plugins.mobile.celery_tasks.PushNotificationService')
+def test_send_notification_retries_on_cached_auth_401(mock_service_class: Mock) -> None:
+    mock_service_class.get_external_data.side_effect = _make_http_error(401)
+    mock_service_class.is_cached_auth_401.return_value = True
+
+    notification_payload = {
+        'user_uuid': sentinel.user_uuid,
+        'notification_type': sentinel.notification_type,
+        'title': sentinel.title,
+        'body': sentinel.body,
+        'extra': sentinel.extra,
+    }
+    # When called directly (not via apply_async), Celery's task.retry()
+    # re-raises the original exception rather than Retry; patch it so we can
+    # assert that retry was requested.
+    with patch.object(send_notification, 'retry', side_effect=Retry()) as mock_retry:
+        with pytest.raises(Retry):
+            send_notification(sentinel.config, notification_payload)
+    mock_retry.assert_called_once()
+
+
+@patch('wazo_webhookd.plugins.mobile.celery_tasks.PushNotificationService')
+def test_send_notification_propagates_non_cached_auth_errors(
+    mock_service_class: Mock,
+) -> None:
+    mock_service_class.get_external_data.side_effect = _make_http_error(500)
+    mock_service_class.is_cached_auth_401.return_value = False
+
+    notification_payload = {
+        'user_uuid': sentinel.user_uuid,
+        'notification_type': sentinel.notification_type,
+        'title': sentinel.title,
+        'body': sentinel.body,
+        'extra': sentinel.extra,
+    }
+    with pytest.raises(requests.HTTPError):
+        send_notification(sentinel.config, notification_payload)
+
+
+@patch('wazo_webhookd.plugins.mobile.celery_tasks.PushNotificationService')
+def test_send_notification_returns_false_on_404(mock_service_class: Mock) -> None:
+    mock_service_class.get_external_data.side_effect = _make_http_error(404)
+
+    notification_payload = {
+        'user_uuid': sentinel.user_uuid,
+        'notification_type': sentinel.notification_type,
+        'title': sentinel.title,
+        'body': sentinel.body,
+        'extra': sentinel.extra,
+    }
+    assert send_notification(sentinel.config, notification_payload) is False
+    # 404 takes precedence; is_cached_auth_401 must not be consulted
+    mock_service_class.is_cached_auth_401.assert_not_called()

--- a/wazo_webhookd/plugins/mobile/tests/test_celery_tasks.py
+++ b/wazo_webhookd/plugins/mobile/tests/test_celery_tasks.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock, patch, sentinel
 
 import pytest
 import requests
-from celery.exceptions import Retry
 
 from ..celery_tasks import send_notification
 
@@ -52,32 +51,8 @@ def test_send_notification(
 
 
 @patch('wazo_webhookd.plugins.mobile.celery_tasks.PushNotificationService')
-def test_send_notification_retries_on_cached_auth_401(mock_service_class: Mock) -> None:
-    mock_service_class.get_external_data.side_effect = _make_http_error(401)
-    mock_service_class.is_cached_auth_401.return_value = True
-
-    notification_payload = {
-        'user_uuid': sentinel.user_uuid,
-        'notification_type': sentinel.notification_type,
-        'title': sentinel.title,
-        'body': sentinel.body,
-        'extra': sentinel.extra,
-    }
-    # When called directly (not via apply_async), Celery's task.retry()
-    # re-raises the original exception rather than Retry; patch it so we can
-    # assert that retry was requested.
-    with patch.object(send_notification, 'retry', side_effect=Retry()) as mock_retry:
-        with pytest.raises(Retry):
-            send_notification(sentinel.config, notification_payload)
-    mock_retry.assert_called_once()
-
-
-@patch('wazo_webhookd.plugins.mobile.celery_tasks.PushNotificationService')
-def test_send_notification_propagates_non_cached_auth_errors(
-    mock_service_class: Mock,
-) -> None:
+def test_send_notification_propagates_http_errors(mock_service_class: Mock) -> None:
     mock_service_class.get_external_data.side_effect = _make_http_error(500)
-    mock_service_class.is_cached_auth_401.return_value = False
 
     notification_payload = {
         'user_uuid': sentinel.user_uuid,
@@ -102,5 +77,3 @@ def test_send_notification_returns_false_on_404(mock_service_class: Mock) -> Non
         'extra': sentinel.extra,
     }
     assert send_notification(sentinel.config, notification_payload) is False
-    # 404 takes precedence; is_cached_auth_401 must not be consulted
-    mock_service_class.is_cached_auth_401.assert_not_called()

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -368,29 +368,39 @@ class Service:
     def get_external_data(
         cls, config: WebhookdConfigDict, user_uuid: str
     ) -> tuple[ExternalMobileDict, ExternalConfigDict, str]:
-        auth, jwt = cls.get_auth(config)
-        try:
-            external_tokens: ExternalMobileDict = auth.external.get('mobile', user_uuid)
-            tenant_uuid = auth.users.get(user_uuid)['tenant_uuid']
+        # Retry in-band on cached-auth 401: same worker, same call stack,
+        # guaranteed-fresh cache on the second attempt. Sidesteps Celery's
+        # broker-mediated retry which has no worker affinity and would let
+        # the retry bounce to another worker whose cache is still stale.
+        for attempt in range(2):
+            auth, jwt = cls.get_auth(config)
             try:
-                external_config: ExternalConfigDict = auth.external.get_config(
-                    'mobile', tenant_uuid
+                external_tokens: ExternalMobileDict = auth.external.get(
+                    'mobile', user_uuid
                 )
+                tenant_uuid = auth.users.get(user_uuid)['tenant_uuid']
+                try:
+                    external_config: ExternalConfigDict = auth.external.get_config(
+                        'mobile', tenant_uuid
+                    )
+                except HTTPError as e:
+                    if e.response is not None and e.response.status_code != 404:
+                        raise
+                    external_config = EMPTY_EXTERNAL_CONFIG
+                return external_tokens, external_config, jwt
             except HTTPError as e:
-                if e.response is not None and e.response.status_code != 404:
-                    raise
-                external_config = EMPTY_EXTERNAL_CONFIG
-        except HTTPError as e:
-            if cls.is_cached_auth_401(e):
-                logger.warning(
-                    'Cached webhookd service token rejected by wazo-auth '
-                    '(HTTP 401 on %s); invalidating cache.',
-                    e.response.url,
-                )
-                cls.invalidate_auth_cache()
-            raise
+                if attempt == 0 and cls.is_cached_auth_401(e):
+                    logger.warning(
+                        'Cached webhookd service token rejected by wazo-auth '
+                        '(HTTP 401 on %s); invalidating cache and retrying '
+                        'inline.',
+                        e.response.url,
+                    )
+                    cls.invalidate_auth_cache()
+                    continue
+                raise
 
-        return external_tokens, external_config, jwt
+        raise AssertionError('get_external_data retry loop fell through')
 
     @classmethod
     def run(

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -377,7 +377,7 @@ class Service:
                     'mobile', tenant_uuid
                 )
             except HTTPError as e:
-                if e.response and e.response.status_code != 404:
+                if e.response is not None and e.response.status_code != 404:
                     raise
                 external_config = EMPTY_EXTERNAL_CONFIG
         except HTTPError as e:

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -308,6 +308,13 @@ class Service:
         # with password-hashing auth on every push event
         # which is harmful during peak-load / activity burst
         now = time.monotonic()
+        logger.info(
+            'get_auth called (cache=%s, now=%.0f, expires=%.0f, ttl=%.0fs)',
+            'warm' if cls._auth_cache is not None else 'cold',
+            now,
+            cls._auth_cache_expires_at,
+            max(0.0, cls._auth_cache_expires_at - now),
+        )
         if cls._auth_cache is not None and now < cls._auth_cache_expires_at - 60:
             logger.debug(
                 'Cache hit on auth token (now=%d, expires=%d)',

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, NotRequired, TypedDict
 
 import httpx
 from celery import Task
-from celery.signals import task_failure
 from requests.exceptions import HTTPError
 from wazo_auth_client import Client as AuthClient
 from wazo_bus.resources.voicemail.types import VoicemailMessageDict
@@ -356,40 +355,40 @@ class Service:
         cls._auth_cache_expires_at = 0.0
 
     @classmethod
-    def _on_task_failure(
-        cls, sender: Any = None, exception: BaseException | None = None, **_: Any
-    ) -> None:
-        if not isinstance(exception, HTTPError):
-            return
-        response = exception.response
-        if response is None or response.status_code != 401:
-            return
-        if cls._auth_url_base is None or not response.url.startswith(
-            cls._auth_url_base
-        ):
-            return
-        logger.warning(
-            'Cached webhookd service token rejected by wazo-auth (HTTP 401 on %s); '
-            'invalidating cache so the next task retry mints a fresh token.',
-            response.url,
+    def is_cached_auth_401(cls, exc: HTTPError) -> bool:
+        """True iff `exc` is a 401 from a call against the cached AuthClient."""
+        return (
+            exc.response is not None
+            and exc.response.status_code == 401
+            and cls._auth_url_base is not None
+            and exc.response.url.startswith(cls._auth_url_base)
         )
-        cls.invalidate_auth_cache()
 
     @classmethod
     def get_external_data(
         cls, config: WebhookdConfigDict, user_uuid: str
     ) -> tuple[ExternalMobileDict, ExternalConfigDict, str]:
         auth, jwt = cls.get_auth(config)
-        external_tokens: ExternalMobileDict = auth.external.get('mobile', user_uuid)
-        tenant_uuid = auth.users.get(user_uuid)['tenant_uuid']
         try:
-            external_config: ExternalConfigDict = auth.external.get_config(
-                'mobile', tenant_uuid
-            )
+            external_tokens: ExternalMobileDict = auth.external.get('mobile', user_uuid)
+            tenant_uuid = auth.users.get(user_uuid)['tenant_uuid']
+            try:
+                external_config: ExternalConfigDict = auth.external.get_config(
+                    'mobile', tenant_uuid
+                )
+            except HTTPError as e:
+                if e.response and e.response.status_code != 404:
+                    raise
+                external_config = EMPTY_EXTERNAL_CONFIG
         except HTTPError as e:
-            if e.response and e.response.status_code != 404:
-                raise
-            external_config = EMPTY_EXTERNAL_CONFIG
+            if cls.is_cached_auth_401(e):
+                logger.warning(
+                    'Cached webhookd service token rejected by wazo-auth '
+                    '(HTTP 401 on %s); invalidating cache.',
+                    e.response.url,
+                )
+                cls.invalidate_auth_cache()
+            raise
 
         return external_tokens, external_config, jwt
 
@@ -409,7 +408,22 @@ class Service:
         ):
             return None
 
-        external_tokens, external_config, jwt = cls.get_external_data(config, user_uuid)
+        try:
+            external_tokens, external_config, jwt = cls.get_external_data(
+                config, user_uuid
+            )
+        except HTTPError as e:
+            if cls.is_cached_auth_401(e):
+                # cache already invalidated by get_external_data; retry the
+                # task so the next attempt mints a fresh token.
+                raise HookRetry(
+                    {
+                        "error": str(e),
+                        "reason": "cached webhookd-service token rejected by wazo-auth",
+                    }
+                )
+            raise
+
         push = PushNotification(task, config, external_tokens, external_config, jwt)
 
         data = event.get('data')
@@ -424,10 +438,6 @@ class Service:
 
         logger.error('No matching notification type for event %s', name)
         return None
-
-
-# task failure handlers e.g. token cache invalidation
-task_failure.connect(Service._on_task_failure, weak=False)
 
 
 def generate_timestamp() -> str:

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -308,7 +308,7 @@ class Service:
         # with password-hashing auth on every push event
         # which is harmful during peak-load / activity burst
         now = time.monotonic()
-        logger.info(
+        logger.debug(
             'get_auth called (cache=%s, now=%.0f, expires=%.0f, ttl=%.0fs)',
             'warm' if cls._auth_cache is not None else 'cold',
             now,
@@ -323,7 +323,7 @@ class Service:
             )
             return cls._auth_cache
 
-        logger.debug(
+        logger.info(
             'Cache miss on auth token (now=%d, expires=%d)',
             now,
             cls._auth_cache_expires_at,

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -377,39 +377,37 @@ class Service:
     def get_external_data(
         cls, config: WebhookdConfigDict, user_uuid: str
     ) -> tuple[ExternalMobileDict, ExternalConfigDict, str]:
-        # Retry in-band on cached-auth 401: same worker, same call stack,
-        # guaranteed-fresh cache on the second attempt. Sidesteps Celery's
-        # broker-mediated retry which has no worker affinity and would let
-        # the retry bounce to another worker whose cache is still stale.
-        for attempt in range(2):
-            auth, jwt = cls.get_auth(config)
-            try:
-                external_tokens: ExternalMobileDict = auth.external.get(
-                    'mobile', user_uuid
-                )
-                tenant_uuid = auth.users.get(user_uuid)['tenant_uuid']
-                try:
-                    external_config: ExternalConfigDict = auth.external.get_config(
-                        'mobile', tenant_uuid
-                    )
-                except HTTPError as e:
-                    if e.response is not None and e.response.status_code != 404:
-                        raise
-                    external_config = EMPTY_EXTERNAL_CONFIG
-                return external_tokens, external_config, jwt
-            except HTTPError as e:
-                if attempt == 0 and cls.is_cached_auth_401(e):
-                    logger.warning(
-                        'Cached webhookd service token rejected by wazo-auth '
-                        '(HTTP 401 on %s); invalidating cache and retrying '
-                        'inline.',
-                        e.response.url,
-                    )
-                    cls.invalidate_auth_cache()
-                    continue
+        try:
+            return cls._fetch_external_data(config, user_uuid)
+        except HTTPError as e:
+            # retry inline for cache refresh; ensure celery task gets cache
+            # benefit in same worker
+            if not cls.is_cached_auth_401(e):
                 raise
+            logger.warning(
+                'Cached webhookd service token rejected by wazo-auth '
+                '(HTTP 401 on %s); invalidating cache and retrying inline.',
+                e.response.url,
+            )
+            cls.invalidate_auth_cache()
+            return cls._fetch_external_data(config, user_uuid)
 
-        raise AssertionError('get_external_data retry loop fell through')
+    @classmethod
+    def _fetch_external_data(
+        cls, config: WebhookdConfigDict, user_uuid: str
+    ) -> tuple[ExternalMobileDict, ExternalConfigDict, str]:
+        auth, jwt = cls.get_auth(config)
+        external_tokens: ExternalMobileDict = auth.external.get('mobile', user_uuid)
+        tenant_uuid = auth.users.get(user_uuid)['tenant_uuid']
+        try:
+            external_config: ExternalConfigDict = auth.external.get_config(
+                'mobile', tenant_uuid
+            )
+        except HTTPError as e:
+            if e.response is not None and e.response.status_code != 404:
+                raise
+            external_config = EMPTY_EXTERNAL_CONFIG
+        return external_tokens, external_config, jwt
 
     @classmethod
     def run(

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -360,16 +360,18 @@ class Service:
         logger.debug('invalidating auth token cache')
         cls._auth_cache = None
         cls._auth_cache_expires_at = 0.0
+        cls._auth_url_base = None
 
     @classmethod
     def is_cached_auth_401(cls, exc: HTTPError) -> bool:
         """True iff `exc` is a 401 from a call against the cached AuthClient."""
-        return (
-            exc.response is not None
-            and exc.response.status_code == 401
-            and cls._auth_url_base is not None
-            and exc.response.url.startswith(cls._auth_url_base)
-        )
+        if cls._auth_cache is None or cls._auth_url_base is None:
+            return False
+        if exc.response is None or exc.response.status_code != 401:
+            return False
+        url = exc.response.url
+        base = cls._auth_url_base
+        return url == base or url.startswith(base + '/')
 
     @classmethod
     def get_external_data(
@@ -431,8 +433,9 @@ class Service:
             )
         except HTTPError as e:
             if cls.is_cached_auth_401(e):
-                # cache already invalidated by get_external_data; retry the
-                # task so the next attempt mints a fresh token.
+                # get_external_data already retried inline with a fresh token
+                # and still got 401; surface as HookRetry so hook_runner_task
+                # backs off before the next attempt.
                 raise HookRetry(
                     {
                         "error": str(e),

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -310,23 +310,39 @@ class Service:
         # which is harmful during peak-load / activity burst
         now = time.monotonic()
         if cls._auth_cache is not None and now < cls._auth_cache_expires_at - 60:
+            logger.debug(
+                'Cache hit on auth token (now=%d, expires=%d)',
+                now,
+                cls._auth_cache_expires_at,
+            )
             return cls._auth_cache
+
+        logger.debug(
+            'Cache miss on auth token (now=%d, expires=%d)',
+            now,
+            cls._auth_cache_expires_at,
+        )
         auth_config = dict(config['auth'])
         # FIXME(sileht): Keep the certificate
         auth_config['verify_certificate'] = False
         auth = AuthClient(**auth_config)
         expiration = TASK_AUTH_TOKEN_EXPIRATION
         token: TokenDict = auth.token.new('wazo_user', expiration=expiration)
-        auth.set_token(token["token"])
-        jwt = token.get("metadata", {}).get("jwt", "")
+        auth.set_token(token['token'])
+        jwt = token.get('metadata', {}).get('jwt', '')
         return cls.prime_cache(auth, jwt, expiration)
 
     @classmethod
     def prime_cache(
         cls, auth: AuthClient, jwt: str, expiration: int
     ) -> tuple[AuthClient, str]:
+        now = time.monotonic()
+        expires_at = now + expiration
+        logger.debug(
+            'priming auth token cache (now=%d, expires=%d)', now, now + expiration
+        )
         cls._auth_cache = (auth, jwt)
-        cls._auth_cache_expires_at = time.monotonic() + expiration
+        cls._auth_cache_expires_at = expires_at
         cls._auth_url_base = auth.url()
         # prevent re-auth without cache management through get_auth
         auth.username = None
@@ -335,6 +351,7 @@ class Service:
 
     @classmethod
     def invalidate_auth_cache(cls) -> None:
+        logger.debug('invalidating auth token cache')
         cls._auth_cache = None
         cls._auth_cache_expires_at = 0.0
 

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, NotRequired, TypedDict
 
 import httpx
 from celery import Task
+from celery.signals import task_failure
 from requests.exceptions import HTTPError
 from wazo_auth_client import Client as AuthClient
 from wazo_bus.resources.voicemail.types import VoicemailMessageDict
@@ -130,6 +131,9 @@ REQUEST_TIMEOUTS = httpx.Timeout(connect=10, read=15, write=15, pool=None)
 
 DEFAULT_ANDROID_CHANNEL_ID = 'io.wazo.songbird'
 
+# auth token for celery tasks live 1h
+TASK_AUTH_TOKEN_EXPIRATION = 3600
+
 
 class NotificationType(StrEnum):
     MESSAGE_RECEIVED = 'messageReceived'
@@ -163,6 +167,7 @@ class Service:
     _config: WebhookdConfigDict
     _auth_cache: ClassVar[tuple[AuthClient, str] | None] = None
     _auth_cache_expires_at: ClassVar[float] = 0.0
+    _auth_url_base: ClassVar[str | None] = None
 
     def load(self, dependencies: ServicePluginDependencyDict) -> None:
         bus_consumer = dependencies['bus_consumer']
@@ -300,6 +305,9 @@ class Service:
 
     @classmethod
     def get_auth(cls, config: WebhookdConfigDict) -> tuple[AuthClient, str]:
+        # cache auth token to avoid hammering wazo-auth
+        # with password-hashing auth on every push event
+        # which is harmful during peak-load / activity burst
         now = time.monotonic()
         if cls._auth_cache is not None and now < cls._auth_cache_expires_at - 60:
             return cls._auth_cache
@@ -307,14 +315,48 @@ class Service:
         # FIXME(sileht): Keep the certificate
         auth_config['verify_certificate'] = False
         auth = AuthClient(**auth_config)
-        token: TokenDict = auth.token.new('wazo_user', expiration=3600)
+        expiration = TASK_AUTH_TOKEN_EXPIRATION
+        token: TokenDict = auth.token.new('wazo_user', expiration=expiration)
         auth.set_token(token["token"])
         jwt = token.get("metadata", {}).get("jwt", "")
+        return cls.prime_cache(auth, jwt, expiration)
+
+    @classmethod
+    def prime_cache(
+        cls, auth: AuthClient, jwt: str, expiration: int
+    ) -> tuple[AuthClient, str]:
+        cls._auth_cache = (auth, jwt)
+        cls._auth_cache_expires_at = time.monotonic() + expiration
+        cls._auth_url_base = auth.url()
+        # prevent re-auth without cache management through get_auth
         auth.username = None
         auth.password = None
-        cls._auth_cache = (auth, jwt)
-        cls._auth_cache_expires_at = now + 3600
         return cls._auth_cache
+
+    @classmethod
+    def invalidate_auth_cache(cls) -> None:
+        cls._auth_cache = None
+        cls._auth_cache_expires_at = 0.0
+
+    @classmethod
+    def _on_task_failure(
+        cls, sender: Any = None, exception: BaseException | None = None, **_: Any
+    ) -> None:
+        if not isinstance(exception, HTTPError):
+            return
+        response = exception.response
+        if response is None or response.status_code != 401:
+            return
+        if cls._auth_url_base is None or not response.url.startswith(
+            cls._auth_url_base
+        ):
+            return
+        logger.warning(
+            'Cached webhookd service token rejected by wazo-auth (HTTP 401 on %s); '
+            'invalidating cache so the next task retry mints a fresh token.',
+            response.url,
+        )
+        cls.invalidate_auth_cache()
 
     @classmethod
     def get_external_data(
@@ -365,6 +407,10 @@ class Service:
 
         logger.error('No matching notification type for event %s', name)
         return None
+
+
+# task failure handlers e.g. token cache invalidation
+task_failure.connect(Service._on_task_failure, weak=False)
 
 
 def generate_timestamp() -> str:

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import json
 import logging
 import tempfile
+import time
 import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NotRequired, TypedDict, cast
 
 import httpx
 from celery import Task
@@ -160,6 +161,8 @@ MAP_NAME_TO_NOTIFICATION_TYPE = {
 class Service:
     subscription_service: SubscriptionService
     _config: WebhookdConfigDict
+    _auth_cache: ClassVar[tuple[AuthClient, str] | None] = None
+    _auth_cache_expires_at: ClassVar[float] = 0.0
 
     def load(self, dependencies: ServicePluginDependencyDict) -> None:
         bus_consumer = dependencies['bus_consumer']
@@ -297,6 +300,9 @@ class Service:
 
     @classmethod
     def get_auth(cls, config: WebhookdConfigDict) -> tuple[AuthClient, str]:
+        now = time.monotonic()
+        if cls._auth_cache is not None and now < cls._auth_cache_expires_at - 60:
+            return cls._auth_cache
         auth_config = dict(config['auth'])
         # FIXME(sileht): Keep the certificate
         auth_config['verify_certificate'] = False
@@ -306,7 +312,9 @@ class Service:
         jwt = token.get("metadata", {}).get("jwt", "")
         auth.username = None
         auth.password = None
-        return auth, jwt
+        cls._auth_cache = (auth, jwt)
+        cls._auth_cache_expires_at = now + 3600
+        return cls._auth_cache
 
     @classmethod
     def get_external_data(

--- a/wazo_webhookd/services/mobile/tests/test_service.py
+++ b/wazo_webhookd/services/mobile/tests/test_service.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest.mock import MagicMock, patch
+
+from ..plugin import Service
+
+
+def _make_config():
+    return {
+        'auth': {
+            'host': 'localhost',
+            'username': 'webhookd-service',
+            'password': 'secret',
+        }
+    }
+
+
+def _make_mock_auth_client(jwt='test-jwt'):
+    mock_client = MagicMock()
+    mock_client.token.new.return_value = {
+        'token': 'wazo-token-uuid',
+        'metadata': {'jwt': jwt},
+    }
+    return mock_client
+
+
+class TestGetAuthCaching:
+    def setup_method(self):
+        Service._auth_cache = None
+        Service._auth_cache_expires_at = 0.0
+
+    def test_get_auth_creates_token_on_first_call(self):
+        mock_client = _make_mock_auth_client()
+        with patch(
+            'wazo_webhookd.services.mobile.plugin.AuthClient', return_value=mock_client
+        ):
+            auth, jwt = Service.get_auth(_make_config())
+
+        mock_client.token.new.assert_called_once_with('wazo_user', expiration=3600)
+        assert jwt == 'test-jwt'
+        assert auth is mock_client
+
+    def test_get_auth_reuses_cached_token_within_ttl(self):
+        mock_client = _make_mock_auth_client()
+        with patch(
+            'wazo_webhookd.services.mobile.plugin.AuthClient', return_value=mock_client
+        ):
+            auth1, jwt1 = Service.get_auth(_make_config())
+            auth2, jwt2 = Service.get_auth(_make_config())
+
+        mock_client.token.new.assert_called_once()
+        assert auth1 is auth2
+        assert jwt1 == jwt2
+
+    def test_get_auth_refreshes_token_after_expiry(self):
+        mock_client = _make_mock_auth_client()
+        with patch(
+            'wazo_webhookd.services.mobile.plugin.AuthClient', return_value=mock_client
+        ):
+            Service.get_auth(_make_config())  # call 1: cache miss → new token
+            Service.get_auth(_make_config())  # call 2: cache hit → no new token
+            Service._auth_cache_expires_at = 0.0  # simulate expiry
+            Service.get_auth(_make_config())  # call 3: expired → new token
+
+        # 2 new tokens: call 1 and call 3; call 2 was served from cache
+        assert mock_client.token.new.call_count == 2

--- a/wazo_webhookd/services/mobile/tests/test_service.py
+++ b/wazo_webhookd/services/mobile/tests/test_service.py
@@ -146,21 +146,65 @@ class TestInvalidateAuthCache:
 
 
 class TestGetExternalData:
-    """get_external_data invalidates the cache on cached-auth 401 then re-raises."""
+    """get_external_data retries inline on cached-auth 401."""
 
     def setup_method(self):
         _reset_service_cache()
 
-    def test_invalidates_cache_on_cached_auth_401(self):
-        mock_client = _prime_cache(base_url='https://localhost:9497/0.1')
-        mock_client.external.get.side_effect = _make_http_error(
+    def test_inline_retries_on_cached_auth_401(self):
+        """First call returns 401 from cached auth; cache invalidated; second
+        call mints a fresh token and succeeds."""
+        stale_client = _prime_cache(base_url='https://localhost:9497/0.1')
+        stale_client.external.get.side_effect = _make_http_error(
             401, 'https://localhost:9497/0.1/users/user-1/external/mobile'
         )
 
-        with pytest.raises(requests.HTTPError):
-            Service.get_external_data(_make_config(), 'user-1')
+        fresh_client = _make_mock_auth_client(jwt='fresh-jwt')
+        fresh_client.external.get.return_value = {'token': 'tok'}
+        fresh_client.users.get.return_value = {'tenant_uuid': 'tenant-1'}
+        fresh_client.external.get_config.side_effect = _make_http_error(
+            404, 'https://localhost:9497/0.1/external/mobile/config'
+        )
 
-        assert Service._auth_cache is None
+        # After invalidate_auth_cache, get_auth instantiates a new AuthClient.
+        with patch(
+            'wazo_webhookd.services.mobile.plugin.AuthClient',
+            return_value=fresh_client,
+        ):
+            external_tokens, external_config, jwt = Service.get_external_data(
+                _make_config(), 'user-1'
+            )
+
+        assert external_tokens == {'token': 'tok'}
+        assert external_config == EMPTY_EXTERNAL_CONFIG
+        assert jwt == 'fresh-jwt'
+        # cache re-primed with fresh client
+        assert Service._auth_cache == (fresh_client, 'fresh-jwt')
+
+    def test_persistent_cached_auth_401_propagates(self):
+        """Both attempts return 401 → HTTPError propagates; cache cleared."""
+        stale_client = _prime_cache(base_url='https://localhost:9497/0.1')
+        stale_client.external.get.side_effect = _make_http_error(
+            401, 'https://localhost:9497/0.1/users/user-1/external/mobile'
+        )
+
+        # Fresh client returned by get_auth's re-mint also fails with 401.
+        fresh_client = _make_mock_auth_client()
+        fresh_client.external.get.side_effect = _make_http_error(
+            401, 'https://localhost:9497/0.1/users/user-1/external/mobile'
+        )
+
+        with patch(
+            'wazo_webhookd.services.mobile.plugin.AuthClient',
+            return_value=fresh_client,
+        ):
+            with pytest.raises(requests.HTTPError):
+                Service.get_external_data(_make_config(), 'user-1')
+
+        # last attempt's failure left the cache primed with the fresh client;
+        # an external caller (Service.run -> HookRetry, or send_notification
+        # -> task.retry) is responsible for any further recovery.
+        assert Service._auth_cache == (fresh_client, 'test-jwt')
 
     def test_propagates_non_401_without_invalidation(self):
         mock_client = _prime_cache(base_url='https://localhost:9497/0.1')

--- a/wazo_webhookd/services/mobile/tests/test_service.py
+++ b/wazo_webhookd/services/mobile/tests/test_service.py
@@ -191,6 +191,17 @@ class TestGetExternalData:
         # cache untouched: 404 is not the cached-auth-401 signal
         assert Service._auth_cache is not None
 
+    def test_external_config_non_404_propagates(self):
+        mock_client = _prime_cache()
+        mock_client.external.get.return_value = {'token': 'tok'}
+        mock_client.users.get.return_value = {'tenant_uuid': 'tenant-1'}
+        mock_client.external.get_config.side_effect = _make_http_error(
+            500, 'https://localhost:9497/0.1/external/mobile/config'
+        )
+
+        with pytest.raises(requests.HTTPError):
+            Service.get_external_data(_make_config(), 'user-1')
+
 
 class TestServiceRunAuthRetry:
     """Service.run converts cached-auth 401 into HookRetry for hook_runner_task."""

--- a/wazo_webhookd/services/mobile/tests/test_service.py
+++ b/wazo_webhookd/services/mobile/tests/test_service.py
@@ -130,6 +130,25 @@ class TestIsCachedAuth401:
 
         assert Service.is_cached_auth_401(exc) is False
 
+    def test_false_after_invalidation_even_if_url_matches(self):
+        # A 401 escaping from a fresh-mint path (e.g. token.new rejected for
+        # bad service credentials) must not be classified as a cached-auth
+        # race once the cache has been dropped — otherwise Service.run would
+        # raise HookRetry and burn hook_max_attempts against a permanent
+        # credential failure.
+        _prime_cache(base_url='https://localhost:9497/0.1')
+        Service.invalidate_auth_cache()
+        exc = _make_http_error(401, 'https://localhost:9497/0.1/token')
+
+        assert Service.is_cached_auth_401(exc) is False
+
+    def test_false_when_url_only_overlaps_prefix(self):
+        # base 'https://host/0.1' must NOT match e.g. '/0.10' coexisting
+        _prime_cache(base_url='https://localhost:9497/0.1')
+        exc = _make_http_error(401, 'https://localhost:9497/0.10/users/abc')
+
+        assert Service.is_cached_auth_401(exc) is False
+
 
 class TestInvalidateAuthCache:
     def setup_method(self):
@@ -138,11 +157,13 @@ class TestInvalidateAuthCache:
     def test_clears_state(self):
         _prime_cache()
         assert Service._auth_cache is not None
+        assert Service._auth_url_base is not None
 
         Service.invalidate_auth_cache()
 
         assert Service._auth_cache is None
         assert Service._auth_cache_expires_at == 0.0
+        assert Service._auth_url_base is None
 
 
 class TestGetExternalData:

--- a/wazo_webhookd/services/mobile/tests/test_service.py
+++ b/wazo_webhookd/services/mobile/tests/test_service.py
@@ -1,12 +1,18 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
-from celery.signals import task_failure
 
-from ..plugin import Service
+from wazo_webhookd.services.helpers import HookRetry
+
+from ..plugin import EMPTY_EXTERNAL_CONFIG, Service
+
+if TYPE_CHECKING:
+    from wazo_webhookd.database.models import Subscription
 
 
 def _make_config():
@@ -36,10 +42,24 @@ def _make_http_error(status_code, url):
     return requests.HTTPError(response=response)
 
 
+def _reset_service_cache():
+    Service._auth_cache = None
+    Service._auth_cache_expires_at = 0.0
+    Service._auth_url_base = None
+
+
+def _prime_cache(base_url='https://localhost:9497/0.1'):
+    mock_client = _make_mock_auth_client(base_url=base_url)
+    with patch(
+        'wazo_webhookd.services.mobile.plugin.AuthClient', return_value=mock_client
+    ):
+        Service.get_auth(_make_config())
+    return mock_client
+
+
 class TestGetAuthCaching:
     def setup_method(self):
-        Service._auth_cache = None
-        Service._auth_cache_expires_at = 0.0
+        _reset_service_cache()
 
     def test_get_auth_creates_token_on_first_call(self):
         mock_client = _make_mock_auth_client()
@@ -78,22 +98,45 @@ class TestGetAuthCaching:
         assert mock_client.token.new.call_count == 2
 
 
-class TestAuthCacheInvalidation:
+class TestIsCachedAuth401:
+    """The discriminator used by get_external_data and Service.run."""
+
     def setup_method(self):
-        Service._auth_cache = None
-        Service._auth_cache_expires_at = 0.0
-        Service._auth_url_base = None
+        _reset_service_cache()
 
-    def _prime_cache(self, base_url='https://localhost:9497/0.1'):
-        mock_client = _make_mock_auth_client(base_url=base_url)
-        with patch(
-            'wazo_webhookd.services.mobile.plugin.AuthClient', return_value=mock_client
-        ):
-            Service.get_auth(_make_config())
-        return mock_client
+    def test_true_when_401_targets_cached_auth_base_url(self):
+        _prime_cache(base_url='https://localhost:9497/0.1')
+        exc = _make_http_error(401, 'https://localhost:9497/0.1/users/abc')
 
-    def test_invalidate_auth_cache_clears_state(self):
-        self._prime_cache()
+        assert Service.is_cached_auth_401(exc) is True
+
+    def test_false_when_401_from_unrelated_host(self):
+        _prime_cache(base_url='https://localhost:9497/0.1')
+        exc = _make_http_error(
+            401, 'https://fcm.googleapis.com/v1/projects/x/messages:send'
+        )
+
+        assert Service.is_cached_auth_401(exc) is False
+
+    def test_false_when_status_is_not_401(self):
+        _prime_cache()
+        exc = _make_http_error(500, 'https://localhost:9497/0.1/users/abc')
+
+        assert Service.is_cached_auth_401(exc) is False
+
+    def test_false_when_no_cache_base_url(self):
+        # cache never primed -> _auth_url_base is None
+        exc = _make_http_error(401, 'https://localhost:9497/0.1/users/abc')
+
+        assert Service.is_cached_auth_401(exc) is False
+
+
+class TestInvalidateAuthCache:
+    def setup_method(self):
+        _reset_service_cache()
+
+    def test_clears_state(self):
+        _prime_cache()
         assert Service._auth_cache is not None
 
         Service.invalidate_auth_cache()
@@ -101,44 +144,98 @@ class TestAuthCacheInvalidation:
         assert Service._auth_cache is None
         assert Service._auth_cache_expires_at == 0.0
 
-    def test_task_failure_invalidates_cache_on_auth_401(self):
-        self._prime_cache(base_url='https://localhost:9497/0.1')
-        exc = _make_http_error(401, 'https://localhost:9497/0.1/users/abc')
 
-        task_failure.send(sender=None, exception=exc)
+class TestGetExternalData:
+    """get_external_data invalidates the cache on cached-auth 401 then re-raises."""
 
-        assert Service._auth_cache is None
+    def setup_method(self):
+        _reset_service_cache()
 
-    def test_task_failure_ignores_401_from_other_host(self):
-        self._prime_cache(base_url='https://localhost:9497/0.1')
-        # 401 from FCM (Google OAuth2 bearer rejected) — not our service token
-        exc = _make_http_error(
-            401, 'https://fcm.googleapis.com/v1/projects/x/messages:send'
+    def test_invalidates_cache_on_cached_auth_401(self):
+        mock_client = _prime_cache(base_url='https://localhost:9497/0.1')
+        mock_client.external.get.side_effect = _make_http_error(
+            401, 'https://localhost:9497/0.1/users/user-1/external/mobile'
         )
 
-        task_failure.send(sender=None, exception=exc)
-
-        assert Service._auth_cache is not None
-
-    def test_task_failure_ignores_non_401_status(self):
-        self._prime_cache()
-        exc = _make_http_error(500, 'https://localhost:9497/0.1/users/abc')
-
-        task_failure.send(sender=None, exception=exc)
-
-        assert Service._auth_cache is not None
-
-    def test_task_failure_ignores_non_http_error(self):
-        self._prime_cache()
-
-        task_failure.send(sender=None, exception=ValueError('boom'))
-
-        assert Service._auth_cache is not None
-
-    def test_task_failure_no_cache_no_crash(self):
-        assert Service._auth_cache is None
-        exc = _make_http_error(401, 'https://localhost:9497/0.1/users/abc')
-
-        task_failure.send(sender=None, exception=exc)
+        with pytest.raises(requests.HTTPError):
+            Service.get_external_data(_make_config(), 'user-1')
 
         assert Service._auth_cache is None
+
+    def test_propagates_non_401_without_invalidation(self):
+        mock_client = _prime_cache(base_url='https://localhost:9497/0.1')
+        mock_client.external.get.side_effect = _make_http_error(
+            500, 'https://localhost:9497/0.1/users/user-1/external/mobile'
+        )
+
+        with pytest.raises(requests.HTTPError):
+            Service.get_external_data(_make_config(), 'user-1')
+
+        # cache still primed
+        assert Service._auth_cache is not None
+
+    def test_external_config_404_falls_back_to_empty(self):
+        mock_client = _prime_cache()
+        mock_client.external.get.return_value = {'token': 'tok'}
+        mock_client.users.get.return_value = {'tenant_uuid': 'tenant-1'}
+        mock_client.external.get_config.side_effect = _make_http_error(
+            404, 'https://localhost:9497/0.1/external/mobile/config'
+        )
+
+        external_tokens, external_config, jwt = Service.get_external_data(
+            _make_config(), 'user-1'
+        )
+
+        assert external_config == EMPTY_EXTERNAL_CONFIG
+        assert external_tokens == {'token': 'tok'}
+        # cache untouched: 404 is not the cached-auth-401 signal
+        assert Service._auth_cache is not None
+
+
+class TestServiceRunAuthRetry:
+    """Service.run converts cached-auth 401 into HookRetry for hook_runner_task."""
+
+    def setup_method(self):
+        _reset_service_cache()
+
+    def _run(self):
+        task = MagicMock()
+        subscription = cast('Subscription', {'events_user_uuid': 'user-1'})
+        event = {'name': 'user_missed_call', 'data': {'user_uuid': 'user-1'}}
+        return Service.run(task, _make_config(), subscription, event)
+
+    def test_cached_auth_401_raises_hook_retry(self):
+        _prime_cache(base_url='https://localhost:9497/0.1')
+        with patch.object(
+            Service,
+            'get_external_data',
+            side_effect=_make_http_error(
+                401, 'https://localhost:9497/0.1/users/user-1/external/mobile'
+            ),
+        ):
+            with pytest.raises(HookRetry):
+                self._run()
+
+    def test_non_cached_auth_401_propagates_as_http_error(self):
+        _prime_cache(base_url='https://localhost:9497/0.1')
+        with patch.object(
+            Service,
+            'get_external_data',
+            side_effect=_make_http_error(
+                401, 'https://fcm.googleapis.com/v1/projects/x/messages:send'
+            ),
+        ):
+            with pytest.raises(requests.HTTPError):
+                self._run()
+
+    def test_non_401_http_error_propagates_as_http_error(self):
+        _prime_cache()
+        with patch.object(
+            Service,
+            'get_external_data',
+            side_effect=_make_http_error(
+                500, 'https://localhost:9497/0.1/users/user-1/external/mobile'
+            ),
+        ):
+            with pytest.raises(requests.HTTPError):
+                self._run()

--- a/wazo_webhookd/services/mobile/tests/test_service.py
+++ b/wazo_webhookd/services/mobile/tests/test_service.py
@@ -3,6 +3,9 @@
 
 from unittest.mock import MagicMock, patch
 
+import requests
+from celery.signals import task_failure
+
 from ..plugin import Service
 
 
@@ -16,13 +19,21 @@ def _make_config():
     }
 
 
-def _make_mock_auth_client(jwt='test-jwt'):
+def _make_mock_auth_client(jwt='test-jwt', base_url='https://localhost:9497/0.1'):
     mock_client = MagicMock()
     mock_client.token.new.return_value = {
         'token': 'wazo-token-uuid',
         'metadata': {'jwt': jwt},
     }
+    mock_client.url.return_value = base_url
     return mock_client
+
+
+def _make_http_error(status_code, url):
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = url
+    return requests.HTTPError(response=response)
 
 
 class TestGetAuthCaching:
@@ -65,3 +76,69 @@ class TestGetAuthCaching:
 
         # 2 new tokens: call 1 and call 3; call 2 was served from cache
         assert mock_client.token.new.call_count == 2
+
+
+class TestAuthCacheInvalidation:
+    def setup_method(self):
+        Service._auth_cache = None
+        Service._auth_cache_expires_at = 0.0
+        Service._auth_url_base = None
+
+    def _prime_cache(self, base_url='https://localhost:9497/0.1'):
+        mock_client = _make_mock_auth_client(base_url=base_url)
+        with patch(
+            'wazo_webhookd.services.mobile.plugin.AuthClient', return_value=mock_client
+        ):
+            Service.get_auth(_make_config())
+        return mock_client
+
+    def test_invalidate_auth_cache_clears_state(self):
+        self._prime_cache()
+        assert Service._auth_cache is not None
+
+        Service.invalidate_auth_cache()
+
+        assert Service._auth_cache is None
+        assert Service._auth_cache_expires_at == 0.0
+
+    def test_task_failure_invalidates_cache_on_auth_401(self):
+        self._prime_cache(base_url='https://localhost:9497/0.1')
+        exc = _make_http_error(401, 'https://localhost:9497/0.1/users/abc')
+
+        task_failure.send(sender=None, exception=exc)
+
+        assert Service._auth_cache is None
+
+    def test_task_failure_ignores_401_from_other_host(self):
+        self._prime_cache(base_url='https://localhost:9497/0.1')
+        # 401 from FCM (Google OAuth2 bearer rejected) — not our service token
+        exc = _make_http_error(
+            401, 'https://fcm.googleapis.com/v1/projects/x/messages:send'
+        )
+
+        task_failure.send(sender=None, exception=exc)
+
+        assert Service._auth_cache is not None
+
+    def test_task_failure_ignores_non_401_status(self):
+        self._prime_cache()
+        exc = _make_http_error(500, 'https://localhost:9497/0.1/users/abc')
+
+        task_failure.send(sender=None, exception=exc)
+
+        assert Service._auth_cache is not None
+
+    def test_task_failure_ignores_non_http_error(self):
+        self._prime_cache()
+
+        task_failure.send(sender=None, exception=ValueError('boom'))
+
+        assert Service._auth_cache is not None
+
+    def test_task_failure_no_cache_no_crash(self):
+        assert Service._auth_cache is None
+        exc = _make_http_error(401, 'https://localhost:9497/0.1/users/abc')
+
+        task_failure.send(sender=None, exception=exc)
+
+        assert Service._auth_cache is None

--- a/wazo_webhookd/types.py
+++ b/wazo_webhookd/types.py
@@ -45,6 +45,8 @@ class CeleryConfigDict(TypedDict):
     worker_pid_file: str
     worker_min: int
     worker_max: int
+    worker_max_tasks_per_child: int
+    worker_max_memory_per_child: int  # kilobytes
 
 
 class RestApiCorsConfigDict(TypedDict):

--- a/wazo_webhookd/types.py
+++ b/wazo_webhookd/types.py
@@ -46,7 +46,7 @@ class CeleryConfigDict(TypedDict):
     worker_min: int
     worker_max: int
     worker_max_tasks_per_child: int
-    worker_max_memory_per_child: int  # kilobytes
+    worker_max_memory_per_child: int  # KiB (per Celery --max-memory-per-child)
 
 
 class RestApiCorsConfigDict(TypedDict):


### PR DESCRIPTION


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authentication behavior on a high-volume push path (shared cache, 401 retry, and HookRetry semantics); misclassification could affect retries or load on wazo-auth during bursts.
> 
> **Overview**
> Adds a **process-wide class-level cache** for the webhookd service token used when mobile push paths call wazo-auth (`get_auth` / `get_external_data`), so burst traffic does not issue a new `POST /0.1/token` on every Celery task. Cached tokens are reused until near expiry; **401s against the cached auth base URL** trigger cache invalidation and a single inline refetch, with subscription hooks surfacing a persistent failure as **`HookRetry`**.
> 
> **Celery worker recycling** thresholds (`worker_max_tasks_per_child`, `worker_max_memory_per_child`) are now **config-driven** (default max memory per child raised to 150 000 KiB). The direct **`send_notification`** task keeps **404 → false** and propagates other HTTP errors without task-level retry, relying on the shared auth retry logic.
> 
> **Integration tests** assert one token mint for two sequential pushes (API and subscription/bus paths) with a single worker; **unit tests** cover cache TTL, 401 classification, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6fb3cb69c46c27872634bf51ac5817395c292e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->