### PR TITLE
fix: stop sending hard-coded aps.badge in APNS push payloads

### DIFF
--- a/integration_tests/suite/test_mobile_callback.py
+++ b/integration_tests/suite/test_mobile_callback.py
@@ -2291,7 +2291,6 @@ class TestMobileCallbackAPNS(TestMobileCallback):
             assert_that(
                 request['aps'],
                 has_entries(
-                    badge=1,
                     sound='default',
                     alert=has_entries(
                         title='New Voicemail',

--- a/integration_tests/suite/test_mobile_notifications.py
+++ b/integration_tests/suite/test_mobile_notifications.py
@@ -201,7 +201,6 @@ class TestNotifications(BaseIntegrationTest):
         webhookd.mobile_notifications.send(test_notification)
         test = {
             'aps': {
-                'badge': 1,
                 'sound': 'default',
                 'alert': {'title': 'test title', 'body': 'test message'},
             },

--- a/wazo_webhookd/services/mobile/plugin.py
+++ b/wazo_webhookd/services/mobile/plugin.py
@@ -715,6 +715,14 @@ class PushNotification:
             'token' if token_default_topic else 'config',
         )
 
+        # We intentionally do NOT send `aps.badge`. iOS applies the payload
+        # badge to the app icon at delivery (before app code runs) and there
+        # is no `mutable-content` here for a Notification Service Extension to
+        # rewrite it, so a hard-coded `badge: 1` clobbered the count the mobile
+        # app maintains itself (it stuck the icon at 1 / made it flicker). The
+        # app owns the icon badge via UNUserNotificationCenter.setBadgeCount
+        # from its own unread store; omitting `badge` leaves the icon for the
+        # app to manage. See bogue/IOS-CHAT-NOTIFICATIONS.md in wazo-native.
         if (
             notification_type := data['notification_type']
         ) == NotificationType.INCOMING_CALL:
@@ -726,7 +734,7 @@ class PushNotification:
             payload = cast(
                 ApnsPayload,
                 {
-                    'aps': {'alert': data, 'badge': 1},
+                    'aps': {'alert': data},
                     **data,
                 },
             )
@@ -739,7 +747,7 @@ class PushNotification:
             payload = cast(
                 ApnsPayload,
                 {
-                    'aps': {"badge": 1, "sound": "default", "content-available": 1},
+                    'aps': {"sound": "default", "content-available": 1},
                     **data,
                 },
             )
@@ -755,7 +763,7 @@ class PushNotification:
             payload = cast(
                 ApnsPayload,
                 {
-                    'aps': {'badge': 1, 'sound': "default"},
+                    'aps': {'sound': "default"},
                     'data': data,
                 },
             )

--- a/wazo_webhookd/services/mobile/tests/test_apn.py
+++ b/wazo_webhookd/services/mobile/tests/test_apn.py
@@ -67,7 +67,7 @@ class TestAPN(TestCase):
             payload,
             equal_to(
                 {
-                    'aps': {'alert': data, 'badge': 1},
+                    'aps': {'alert': data},
                     'notification_type': NotificationType.INCOMING_CALL,
                     'items': {},
                 }
@@ -104,7 +104,7 @@ class TestAPN(TestCase):
             payload,
             equal_to(
                 {
-                    'aps': {"badge": 1, "sound": "default", "content-available": 1},
+                    'aps': {"sound": "default", "content-available": 1},
                     'notification_type': NotificationType.CANCEL_INCOMING_CALL,
                     'items': {},
                 }
@@ -145,7 +145,7 @@ class TestAPN(TestCase):
             payload,
             equal_to(
                 {
-                    'aps': {"badge": 1, "sound": "default", "content-available": 1},
+                    'aps': {"sound": "default", "content-available": 1},
                     'data': {
                         'notification_type': NotificationType.MESSAGE_RECEIVED,
                         'items': data['items'],


### PR DESCRIPTION
## Summary

Stop sending a hard-coded `aps.badge: 1` in all APNS push notification payloads. The mobile app owns the app-icon badge count itself (via `UNUserNotificationCenter.setBadgeCount` from its own unread store).

iOS applies the payload `badge` to the app icon at **delivery time**, before app code runs, and there is no `mutable-content` / Notification Service Extension here to rewrite it. As a result the hard-coded `badge: 1` clobbered the app-maintained count — sticking the icon at 1 / making it flicker.

## Changes

- `wazo_webhookd/services/mobile/plugin.py` — remove `badge: 1` from the three APNS payloads (incoming call, cancel incoming call, message received) and add an explanatory comment.
- Update unit test expectations in `wazo_webhookd/services/mobile/tests/test_apn.py`.
- Update integration test expectations in `test_mobile_callback.py` and `test_mobile_notifications.py`.

## Test plan

- [ ] `pytest wazo_webhookd/services/mobile/tests/test_apn.py`
- [ ] Integration tests for mobile callback / notifications
- [ ] Verify on-device that the app icon badge reflects the app's own unread count