### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.02
 
 * `PATCH` request bodies to endpoints accepting JSON payload are systematically parsed as JSON, with or without a proper `Content-Type` header;

--- a/etc/wazo-webhookd/config.yml
+++ b/etc/wazo-webhookd/config.yml
@@ -58,10 +58,16 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 enabled_plugins:
   api: true

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -50,6 +50,7 @@ class TestDatabase(AssetLaunchingTestCase):
         return {
             'db_uri': self.db_uri,
             'rest_api': {
+                'min_threads': 10,
                 'max_threads': 10,
             },
         }

--- a/wazo_webhookd/bin/sync_db.py
+++ b/wazo_webhookd/bin/sync_db.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2025-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -82,7 +82,9 @@ def main():
 
     engine = create_engine(
         config['db_uri'],
-        pool_size=config['rest_api']['max_threads'],
+        pool_size=config['rest_api']['min_threads'],
+        max_overflow=config['rest_api']['max_threads']
+        - config['rest_api']['min_threads'],
         pool_pre_ping=True,
     )
     Session = scoped_session(sessionmaker())

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -64,7 +64,8 @@ _DEFAULT_CONFIG = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'consul': {
         'scheme': 'http',

--- a/wazo_webhookd/plugins/subscription/service.py
+++ b/wazo_webhookd/plugins/subscription/service.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -42,7 +42,9 @@ class SubscriptionService:
     ) -> None:
         self._engine = create_engine(
             config['db_uri'],
-            pool_size=config['rest_api']['max_threads'],
+            pool_size=config['rest_api']['min_threads'],
+            max_overflow=config['rest_api']['max_threads']
+            - config['rest_api']['min_threads'],
             pool_pre_ping=True,
         )
         self._Session: scoped_session = scoped_session(sessionmaker())

--- a/wazo_webhookd/plugins/subscription/service.py
+++ b/wazo_webhookd/plugins/subscription/service.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DB_POOL_SPARE_CONN = 10
+
 
 class SubscriptionService:
     # NOTE(sileht): We share the pubsub object, so a plugin that instantiate
@@ -40,11 +42,12 @@ class SubscriptionService:
     def __init__(
         self, config: WebhookdConfigDict, notifier: SubscriptionNotifier
     ) -> None:
+        min_threads = config['rest_api']['min_threads']
+        max_threads = config['rest_api']['max_threads']
         self._engine = create_engine(
             config['db_uri'],
-            pool_size=config['rest_api']['min_threads'],
-            max_overflow=config['rest_api']['max_threads']
-            - config['rest_api']['min_threads'],
+            pool_size=min_threads,
+            max_overflow=max_threads - min_threads + DB_POOL_SPARE_CONN,
             pool_pre_ping=True,
         )
         self._Session: scoped_session = scoped_session(sessionmaker())

--- a/wazo_webhookd/rest_api.py
+++ b/wazo_webhookd/rest_api.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -50,10 +50,11 @@ class CoreRestApi:
         bind_addr = (self.config['listen'], self.config['port'])
 
         wsgi_app = wsgi.WSGIPathInfoDispatcher({'/': app})
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(

--- a/wazo_webhookd/types.py
+++ b/wazo_webhookd/types.py
@@ -60,6 +60,7 @@ class RestApiConfigDict(TypedDict):
     certificate: str | None
     private_key: str | None
     cors: RestApiCorsConfigDict
+    min_threads: int
     max_threads: int
 
 


### PR DESCRIPTION

Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default concurrency and DB connection limits on upgrade (max_threads 10→100) and ties pool sizing to thread settings; misconfiguration could exhaust connections or under-provision under spike load.
> 
> **Overview**
> **REST concurrency** no longer starts a fixed `max_threads` worker pool. The server switches to **`DynamicWSGIServer`** (xivo-lib-python) with **`min_threads`** threads always ready and **`max_threads`** as the upper bound under load.
> 
> **Configuration** adds **`rest_api.min_threads`** (default **10**) and raises the default **`max_threads`** from **10** to **100**, with updated comments in `etc/wazo-webhookd/config.yml` and a **26.08** changelog entry.
> 
> **Database pooling** is aligned with the new model: **`pool_size`** uses **`min_threads`**, and **`max_overflow`** scales toward **`max_threads`** in `sync_db` and **`SubscriptionService`** (the latter adds **`DB_POOL_SPARE_CONN`** extra overflow). **`RestApiConfigDict`** and integration test fixtures include **`min_threads`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd681a986f7a1ab869c125764f59f7c9a7696807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->