### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/etc/wazo-webhookd/config.yml
+++ b/etc/wazo-webhookd/config.yml
@@ -12,8 +12,7 @@ log_file: /var/log/wazo-webhookd.log
 # Authentication server connection settings
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
   key_file: /var/lib/wazo-auth-keys/wazo-webhookd-key.yml
 

--- a/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-webhookd/conf.d/50-default.yml
@@ -2,6 +2,8 @@ rest_api:
   listen: 0.0.0.0
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: webhookd-service
   password: webhookd-password
 db_uri: postgresql://wazo-webhookd:Secr7t@postgres/wazo-webhookd

--- a/wazo_webhookd/config.py
+++ b/wazo_webhookd/config.py
@@ -27,8 +27,7 @@ _DEFAULT_CONFIG = {
     'user': 'wazo-webhookd',
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-webhookd-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth connectivity breaks if merged before nginx and wazo-auth entry-point changes deploy; otherwise limited to default connection settings.
> 
> **Overview**
> Internal **wazo-auth** calls now default to **`localhost:80`** (nginx) instead of the wazo-auth process port **9497**, in both Python defaults (`wazo_webhookd/config.py`) and shipped **`etc/wazo-webhookd/config.yml`**.
> 
> The explicit **`auth.prefix`** default is removed; **`wazo-auth-client`** already uses **`/api/auth`**. **CHANGELOG** documents the new default for 26.09.
> 
> **Integration test** config pins **`port: 9497`** and **`prefix: null`** because those stacks have no nginx and previously inherited the production defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0038ae5f637e6c014863ef80f5cb460d7f8c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->